### PR TITLE
Replace official Chromium build with custom build from Woolyss

### DIFF
--- a/.m1k1o/chromium/Dockerfile
+++ b/.m1k1o/chromium/Dockerfile
@@ -1,25 +1,26 @@
 FROM m1k1o/neko:base
 
 #
-# install chromium
+# install custom chromium build from woolyss with support for hevc/x265
 RUN set -eux; apt-get update; \
-    apt-get install -y --no-install-recommends openbox unzip chromium; \
+    apt-get install -y --no-install-recommends libatk1.0-0 libatk-bridge2.0-0 libatomic1 libcups2 libgtk-3-0 libnss3 libpci3 libxcomposite1 libxss1 openbox xz-utils; \
+    wget -O - /tmp/chromium.tar.xz "https://github.com/macchrome/linchrome/releases/download/v83.0.4103.116-r756066-portable-ungoogled-Lin64/ungoogled-chromium_83.0.4103.116_1.vaapi_linux.tar.xz" | \
+    tar -xJf- -C /usr/lib; \
+    mv /usr/lib/ungoogled-chromium_83.0.4103.116_1.vaapi_linux /usr/lib/chromium; \
     #
-    # install widevine module
-    WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | tail -n 1); \
-    wget -O /tmp/widevine.zip "https://dl.google.com/widevine-cdm/$WIDEVINE_VERSION-linux-x64.zip"; \
-    unzip -p /tmp/widevine.zip libwidevinecdm.so > /usr/lib/chromium/libwidevinecdm.so; \
-    chmod 644 /usr/lib/chromium/libwidevinecdm.so; \
-    rm /tmp/widevine.zip; \
+    # make required changes for sandbox mode
+    mv /usr/lib/chromium/chrome_sandbox /usr/lib/chromium/chrome-sandbox; \
+    chown root:root /usr/lib/chromium/chrome-sandbox; \
+    chmod 4755 /usr/lib/chromium/chrome-sandbox; \
     #
     # clean up
-    apt-get --purge autoremove -y unzip; \
+    apt-get --purge autoremove -y xz-utils; \
     apt-get clean -y; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #
 # copy configuation files
 COPY supervisord.conf /etc/neko/supervisord/chromium.conf
-COPY preferences.json /usr/share/chromium/master_preferences
+COPY preferences.json /usr/lib/chromium/master_preferences
 COPY policies.json /etc/chromium/policies/managed/policies.json
 COPY openbox.xml /etc/neko/openbox.xml

--- a/.m1k1o/chromium/openbox.xml
+++ b/.m1k1o/chromium/openbox.xml
@@ -13,7 +13,7 @@
 
 <applications>
     <!-- Match all windows and remove their decorations (obxprop | grep "^_OB_APP") -->
-    <application class="Chromium*" name="chromium-browser">
+    <application class="Chromium*" name="chromium-devel">
       <decor>no</decor>
       <maximized>true</maximized>
       <focus>yes</focus>

--- a/.m1k1o/chromium/supervisord.conf
+++ b/.m1k1o/chromium/supervisord.conf
@@ -1,6 +1,6 @@
 [program:chromium]
 environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY="%(ENV_DISPLAY)s"
-command=/usr/lib/chromium/chromium --window-position=0,0 --display=%(ENV_DISPLAY)s --start-maximized --bwsi --test-type --force-dark-mode --disable-file-system --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage
+command=/usr/lib/chromium/chrome-wrapper --window-position=0,0 --display=%(ENV_DISPLAY)s --start-maximized --bwsi --test-type --force-dark-mode --disable-file-system --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage
 autorestart=true
 priority=800
 user=%(ENV_USER)s


### PR DESCRIPTION
This pull request implements https://github.com/nurdism/neko/issues/98 by replacing the currently used build of Chromium from the Debian repositories with a custom build from [Woolyss](https://chromium.woolyss.com/) which has support for proprietary codecs like HEVC/x265.