### PR TITLE
Update Chromium and Go

### DIFF
--- a/.m1k1o/base/Dockerfile
+++ b/.m1k1o/base/Dockerfile
@@ -1,7 +1,7 @@
 #
 # STAGE 1: SERVER
 #
-FROM golang:1.14-buster as server
+FROM golang:1.15-buster as server
 WORKDIR /src
 
 #

--- a/.m1k1o/chromium/Dockerfile
+++ b/.m1k1o/chromium/Dockerfile
@@ -4,9 +4,9 @@ FROM m1k1o/neko:base
 # install custom chromium build from woolyss with support for hevc/x265
 RUN set -eux; apt-get update; \
     apt-get install -y --no-install-recommends libatk1.0-0 libatk-bridge2.0-0 libatomic1 libcups2 libgtk-3-0 libnss3 libpci3 libxcomposite1 libxss1 openbox xz-utils; \
-    wget -O - /tmp/chromium.tar.xz "https://github.com/macchrome/linchrome/releases/download/v84.0.4147.89-r768962-portable-ungoogled-Lin64/ungoogled-chromium_84.0.4147.89_1.vaapi_linux.tar.xz" | \
+    wget -O - /tmp/chromium.tar.xz "https://github.com/macchrome/linchrome/releases/download/v84.0.4147.125-r768962-portable-ungoogled-Lin64/ungoogled-chromium_84.0.4147.125_1.vaapi_linux.tar.xz" | \
     tar -xJf- -C /usr/lib; \
-    mv /usr/lib/ungoogled-chromium_84.0.4147.89_1.vaapi_linux /usr/lib/chromium; \
+    mv /usr/lib/ungoogled-chromium_84.0.4147.125_1.vaapi_linux /usr/lib/chromium; \
     #
     # make required changes for sandbox mode
     mv /usr/lib/chromium/chrome_sandbox /usr/lib/chromium/chrome-sandbox; \


### PR DESCRIPTION
Chromium, see: https://github.com/macchrome/linchrome/releases/tag/v84.0.4147.125-r768962-portable-ungoogled-Lin64
Go, see: https://blog.golang.org/go1.15