### PR TITLE
Update NodeJS base image to 12.19

### DIFF
--- a/.m1k1o/base/Dockerfile
+++ b/.m1k1o/base/Dockerfile
@@ -32,7 +32,7 @@ RUN go get -v -t -d . && go build -o bin/neko -i cmd/neko/main.go
 #
 # STAGE 2: CLIENT
 #
-FROM node:12.18-buster-slim as client
+FROM node:12-buster-slim as client
 WORKDIR /src
 
 #


### PR DESCRIPTION
This pull request changes the NodeJS base image tag from `12.18-buster-slim` to `12-buster-slim` to remove the need to manually keep up with new 12.x minor version releases.

The `12-buster-slim` tag is always [equivalent to the latest 12.x minor version](https://hub.docker.com/_/node) (currently 12.19), just like the `1.15-buster` tag of the Go base image is always [equivalent to the latest 1.15.x minor version](https://hub.docker.com/_/golang) (currently 1.15.3).