### PR TITLE
Dockerfile: Update Chromium to v88.0.4324.96

### DIFF
--- a/.m1k1o/chromium/Dockerfile
+++ b/.m1k1o/chromium/Dockerfile
@@ -1,6 +1,6 @@
 FROM m1k1o/neko:base
 
-ARG SRC_URL="https://github.com/macchrome/linchrome/releases/download/v87.0.4280.88-r812852-portable-ungoogled-Lin64/ungoogled-chromium_87.0.4280.88_1.vaapi_linux.tar.xz"
+ARG SRC_URL="https://github.com/macchrome/linchrome/releases/download/v88.0.4324.96-r827102-portable-ungoogled-Lin64/ungoogled-chromium_88.0.4324.96_1.vaapi_linux.tar.xz"
 
 #
 # install custom chromium build from woolyss with support for hevc/x265


### PR DESCRIPTION
See https://github.com/macchrome/linchrome/releases/tag/v88.0.4324.96-r827102-portable-ungoogled-Lin64