### PR TITLE
Feature: default broadcast endpoint config option

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@
 - Added `m1k1o/neko:microsoft-edge` tag.
 - Fixed clipboard sync in chromium based browsers.
 - Added support for implicit control (using `NEKO_IMPLICITCONTROL=1`). That means, users do not need to request control prior usage.
+- Automatically start broadcasting using `NEKO_BROADCAST_URL=rtmp://your-rtmp-endpoint/live` (thanks @konsti).
 
 ### Misc
 - Automatic WebRTC SDP negotiation using onnegotiationneeded handlers. This allows adding/removing track on demand in a session.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -71,6 +71,8 @@ NEKO_LOCKS:
 NEKO_CONTROL_PROTECTION:
   - Control protection means, users can gain control only if at least one admin is in the room.
   - e.g. false
+NEKO_BROADCAST_DEFAULT_ENDPOINT:
+  - Set a default endpoint for broadcast streams. Setting an endpoint will automatically enable broadcasting.
 ```
 
 ## Agruments
@@ -82,36 +84,37 @@ Usage:
   neko serve [flags]
 
 Flags:
-      --audio string                audio codec parameters to use for streaming
-      --audio_bitrate int           audio bitrate in kbit/s (default 128)
-      --bind string                 address/port/socket to serve neko (default "127.0.0.1:8080")
-      --broadcast_pipeline string   custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced
-      --cert string                 path to the SSL cert used to secure the neko server
-      --device string               audio device to capture (default "auto_null.monitor")
-      --display string              XDisplay to capture (default ":99.0")
-      --epr string                  limits the pool of ephemeral ports that ICE UDP connections can allocate from (default "59000-59100")
-      --g722                        use G722 audio codec
-      --h264                        use H264 video codec
-  -h, --help                        help for serve
-      --icelite                     configures whether or not the ice agent should be a lite agent
-      --iceserver strings           describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer (default [stun:stun.l.google.com:19302])
-      --iceservers string           describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer
-      --ipfetch string              automatically fetch IP address from given URL when nat1to1 is not present (default "http://checkip.amazonaws.com")
-      --key string                  path to the SSL key used to secure the neko server
-      --max_fps int                 maximum fps delivered via WebRTC, 0 is for no maximum (default 25)
-      --nat1to1 strings             sets a list of external IP addresses of 1:1 (D)NAT and a candidate type for which the external IP address is used
-      --opus                        use Opus audio codec
-      --password string             password for connecting to stream (default "neko")
-      --password_admin string       admin password for connecting to stream (default "admin")
-      --pcma                        use PCMA audio codec
-      --pcmu                        use PCMU audio codec
-      --proxy                       enable reverse proxy mode
-      --screen string               default screen resolution and framerate (default "1280x720@30")
-      --static string               path to neko client files to serve (default "./www")
-      --video string                video codec parameters to use for streaming
-      --video_bitrate int           video bitrate in kbit/s (default 3072)
-      --vp8                         use VP8 video codec
-      --vp9                         use VP9 video codec
+      --audio string                        audio codec parameters to use for streaming
+      --audio_bitrate int                   audio bitrate in kbit/s (default 128)
+      --bind string                         address/port/socket to serve neko (default "127.0.0.1:8080")
+      --broadcast_default_endpoint string   default endpoint for broadcasting. Setting an endpoint will automatically enable broadcasting
+      --broadcast_pipeline string           custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced
+      --cert string                         path to the SSL cert used to secure the neko server
+      --device string                       audio device to capture (default "auto_null.monitor")
+      --display string                      XDisplay to capture (default ":99.0")
+      --epr string                          limits the pool of ephemeral ports that ICE UDP connections can allocate from (default "59000-59100")
+      --g722                                use G722 audio codec
+      --h264                                use H264 video codec
+  -h, --help                                help for serve
+      --icelite                             configures whether or not the ice agent should be a lite agent
+      --iceserver strings                   describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer (default [stun:stun.l.google.com:19302])
+      --iceservers string                   describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer
+      --ipfetch string                      automatically fetch IP address from given URL when nat1to1 is not present (default "http://checkip.amazonaws.com")
+      --key string                          path to the SSL key used to secure the neko server
+      --max_fps int                         maximum fps delivered via WebRTC, 0 is for no maximum (default 25)
+      --nat1to1 strings                     sets a list of external IP addresses of 1:1 (D)NAT and a candidate type for which the external IP address is used
+      --opus                                use Opus audio codec
+      --password string                     password for connecting to stream (default "neko")
+      --password_admin string               admin password for connecting to stream (default "admin")
+      --pcma                                use PCMA audio codec
+      --pcmu                                use PCMU audio codec
+      --proxy                               enable reverse proxy mode
+      --screen string                       default screen resolution and framerate (default "1280x720@30")
+      --static string                       path to neko client files to serve (default "./www")
+      --video string                        video codec parameters to use for streaming
+      --video_bitrate int                   video bitrate in kbit/s (default 3072)
+      --vp8                                 use VP8 video codec
+      --vp9                                 use VP9 video codec
 
 Global Flags:
       --config string   configuration file path

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -71,8 +71,8 @@ NEKO_LOCKS:
 NEKO_CONTROL_PROTECTION:
   - Control protection means, users can gain control only if at least one admin is in the room.
   - e.g. false
-NEKO_BROADCAST_DEFAULT_ENDPOINT:
-  - Set a default endpoint for broadcast streams. Setting an endpoint will automatically enable broadcasting.
+NEKO_BROADCAST_URL:
+  - Set a default URL for broadcast streams. Setting this value will automatically enable broadcasting when n.eko starts. It can be disabled/changed later in GUI.
 ```
 
 ## Agruments
@@ -84,37 +84,42 @@ Usage:
   neko serve [flags]
 
 Flags:
-      --audio string                        audio codec parameters to use for streaming
-      --audio_bitrate int                   audio bitrate in kbit/s (default 128)
-      --bind string                         address/port/socket to serve neko (default "127.0.0.1:8080")
-      --broadcast_default_endpoint string   default endpoint for broadcasting. Setting an endpoint will automatically enable broadcasting
-      --broadcast_pipeline string           custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced
-      --cert string                         path to the SSL cert used to secure the neko server
-      --device string                       audio device to capture (default "auto_null.monitor")
-      --display string                      XDisplay to capture (default ":99.0")
-      --epr string                          limits the pool of ephemeral ports that ICE UDP connections can allocate from (default "59000-59100")
-      --g722                                use G722 audio codec
-      --h264                                use H264 video codec
-  -h, --help                                help for serve
-      --icelite                             configures whether or not the ice agent should be a lite agent
-      --iceserver strings                   describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer (default [stun:stun.l.google.com:19302])
-      --iceservers string                   describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer
-      --ipfetch string                      automatically fetch IP address from given URL when nat1to1 is not present (default "http://checkip.amazonaws.com")
-      --key string                          path to the SSL key used to secure the neko server
-      --max_fps int                         maximum fps delivered via WebRTC, 0 is for no maximum (default 25)
-      --nat1to1 strings                     sets a list of external IP addresses of 1:1 (D)NAT and a candidate type for which the external IP address is used
-      --opus                                use Opus audio codec
-      --password string                     password for connecting to stream (default "neko")
-      --password_admin string               admin password for connecting to stream (default "admin")
-      --pcma                                use PCMA audio codec
-      --pcmu                                use PCMU audio codec
-      --proxy                               enable reverse proxy mode
-      --screen string                       default screen resolution and framerate (default "1280x720@30")
-      --static string                       path to neko client files to serve (default "./www")
-      --video string                        video codec parameters to use for streaming
-      --video_bitrate int                   video bitrate in kbit/s (default 3072)
-      --vp8                                 use VP8 video codec
-      --vp9                                 use VP9 video codec
+      --audio string                audio codec parameters to use for streaming
+      --audio_bitrate int           audio bitrate in kbit/s (default 128)
+      --bind string                 address/port/socket to serve neko (default "127.0.0.1:8080")
+      --broadcast_pipeline string   custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced
+      --broadcast_url string        URL for broadcasting, setting this value will automatically enable broadcasting
+      --cert string                 path to the SSL cert used to secure the neko server
+      --control_protection          control protection means, users can gain control only if at least one admin is in the room
+      --device string               audio device to capture (default "auto_null.monitor")
+      --display string              XDisplay to capture (default ":99.0")
+      --epr string                  limits the pool of ephemeral ports that ICE UDP connections can allocate from (default "59000-59100")
+      --g722                        use G722 audio codec
+      --h264                        use H264 video codec
+  -h, --help                        help for serve
+      --icelite                     configures whether or not the ice agent should be a lite agent
+      --iceserver strings           describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer (default [stun:stun.l.google.com:19302])
+      --iceservers string           describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer
+      --implicit_control            if enabled members can gain control implicitly
+      --ipfetch string              automatically fetch IP address from given URL when nat1to1 is not present (default "http://checkip.amazonaws.com")
+      --key string                  path to the SSL key used to secure the neko server
+      --locks strings               resources, that will be locked when starting (control, login)
+      --max_fps int                 maximum fps delivered via WebRTC, 0 is for no maximum (default 25)
+      --nat1to1 strings             sets a list of external IP addresses of 1:1 (D)NAT and a candidate type for which the external IP address is used
+      --opus                        use Opus audio codec
+      --password string             password for connecting to stream (default "neko")
+      --password_admin string       admin password for connecting to stream (default "admin")
+      --pcma                        use PCMA audio codec
+      --pcmu                        use PCMU audio codec
+      --proxy                       enable reverse proxy mode
+      --screen string               default screen resolution and framerate (default "1280x720@30")
+      --static string               path to neko client files to serve (default "./www")
+      --tcpmux int                  single TCP mux port for all peers
+      --udpmux int                  single UDP mux port for all peers
+      --video string                video codec parameters to use for streaming
+      --video_bitrate int           video bitrate in kbit/s (default 3072)
+      --vp8                         use VP8 video codec
+      --vp9                         use VP9 video codec
 
 Global Flags:
       --config string   configuration file path

--- a/server/internal/broadcast/manager.go
+++ b/server/internal/broadcast/manager.go
@@ -25,8 +25,8 @@ func New(remote *config.Remote, config *config.Broadcast) *BroadcastManager {
 		logger:  log.With().Str("module", "remote").Logger(),
 		remote:  remote,
 		config:  config,
-		enabled: false,
-		url:     "",
+		enabled: config.Enabled,
+		url:     config.DefaultEndpoint,
 	}
 }
 

--- a/server/internal/broadcast/manager.go
+++ b/server/internal/broadcast/manager.go
@@ -26,7 +26,7 @@ func New(remote *config.Remote, config *config.Broadcast) *BroadcastManager {
 		remote:  remote,
 		config:  config,
 		enabled: config.Enabled,
-		url:     config.DefaultEndpoint,
+		url:     config.URL,
 	}
 }
 

--- a/server/internal/types/config/broadcast.go
+++ b/server/internal/types/config/broadcast.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Broadcast struct {
-	Pipeline        string
-	DefaultEndpoint string
-	Enabled         bool
+	Pipeline string
+	URL      string
+	Enabled  bool
 }
 
 func (Broadcast) Init(cmd *cobra.Command) error {
@@ -17,8 +17,8 @@ func (Broadcast) Init(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.PersistentFlags().String("broadcast_default_endpoint", "", "default endpoint for broadcasting. Setting an endpoint will automatically enable broadcasting")
-	if err := viper.BindPFlag("broadcast_default_endpoint", cmd.PersistentFlags().Lookup("broadcast_default_endpoint")); err != nil {
+	cmd.PersistentFlags().String("broadcast_url", "", "URL for broadcasting, setting this value will automatically enable broadcasting")
+	if err := viper.BindPFlag("broadcast_url", cmd.PersistentFlags().Lookup("broadcast_url")); err != nil {
 		return err
 	}
 
@@ -27,6 +27,6 @@ func (Broadcast) Init(cmd *cobra.Command) error {
 
 func (s *Broadcast) Set() {
 	s.Pipeline = viper.GetString("broadcast_pipeline")
-	s.DefaultEndpoint = viper.GetString("broadcast_default_endpoint")
-	s.Enabled = s.DefaultEndpoint != ""
+	s.URL = viper.GetString("broadcast_url")
+	s.Enabled = s.URL != ""
 }

--- a/server/internal/types/config/broadcast.go
+++ b/server/internal/types/config/broadcast.go
@@ -6,7 +6,9 @@ import (
 )
 
 type Broadcast struct {
-	Pipeline string
+	Pipeline        string
+	DefaultEndpoint string
+	Enabled         bool
 }
 
 func (Broadcast) Init(cmd *cobra.Command) error {
@@ -15,9 +17,16 @@ func (Broadcast) Init(cmd *cobra.Command) error {
 		return err
 	}
 
+	cmd.PersistentFlags().String("broadcast_default_endpoint", "", "default endpoint for broadcasting. Setting an endpoint will automatically enable broadcasting")
+	if err := viper.BindPFlag("broadcast_default_endpoint", cmd.PersistentFlags().Lookup("broadcast_default_endpoint")); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (s *Broadcast) Set() {
 	s.Pipeline = viper.GetString("broadcast_pipeline")
+	s.DefaultEndpoint = viper.GetString("broadcast_default_endpoint")
+	s.Enabled = s.DefaultEndpoint != ""
 }


### PR DESCRIPTION
This PR adds a new configuration option to set a default endpoint for broadcasting.
Adding the default endpoint will automatically start broadcasting when the server starts.

Format:
```
NEKO_BROADCAST_DEFAULT_ENDPOINT="rtmp://your-rtmp-endpoint/live"
```
```
neko serve --broadcast_default_endpoint "rtmp://your-rtmp-endpoint/live"
```