### PR TITLE
Hardware accelerated encoding using Intel QuickSync via VAAPI

### DIFF
--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; apt-get update; \
     # install libclipboard
     set -eux; \
     cd /tmp; \
-    git clone https://github.com/jtanx/libclipboard; \
+    git clone --depth=1 https://github.com/jtanx/libclipboard; \
     cd libclipboard; \
     cmake .; \
     make -j4; \

--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -60,16 +60,26 @@ ARG USERNAME=neko
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-#
-# install dependencies
-RUN set -eux; apt-get update; \
+RUN set -eux; \
+    #
+    # add non-free repo for intel drivers
+    echo deb http://deb.debian.org/debian bullseye main contrib non-free > /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free >> /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian bullseye-updates main contrib non-free >> /etc/apt/sources.list; \
+    apt-get update; \
+    #
+    # install dependencies
     apt-get install -y --no-install-recommends wget ca-certificates supervisor; \
     apt-get install -y --no-install-recommends pulseaudio dbus-x11 xserver-xorg-video-dummy; \
     apt-get install -y --no-install-recommends libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx6; \
     #
-    # gst
+    # intel driver + vaapi
+    apt-get install -y --no-install-recommends intel-media-va-driver-non-free libva2 vainfo; \
+    #
+    # gst + vaapi plugin
     apt-get install -y --no-install-recommends libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-                    gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-pulseaudio; \
+                    gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-pulseaudio \
+                    gstreamer1.0-vaapi ;\
     #
     # fonts
     apt-get install -y --no-install-recommends fonts-takao-mincho; \
@@ -106,6 +116,7 @@ COPY .docker/base/dbus /usr/bin/dbus
 COPY .docker/base/default.pa /etc/pulse/default.pa
 COPY .docker/base/supervisord.conf /etc/neko/supervisord.conf
 COPY .docker/base/xorg.conf /etc/neko/xorg.conf
+COPY .docker/base/add-render-group.sh /usr/bin/add-render-group.sh
 
 #
 # set default envs
@@ -114,6 +125,7 @@ ENV DISPLAY=:99.0
 ENV NEKO_PASSWORD=neko
 ENV NEKO_PASSWORD_ADMIN=admin
 ENV NEKO_BIND=:8080
+ENV RENDER_GID=
 
 #
 # copy static files from previous stages

--- a/.docker/base/add-render-group.sh
+++ b/.docker/base/add-render-group.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-# if no var is passed, noop
-[[ -z "$RENDER_GID" ]] && exit 0
+# if no hwenc required, noop
+[[ -z "$NEKO_HWENC" ]] && exit 0
 
-cnt_gid=$(getent group render | cut -d: -f3)
-[[ -z "$cnt_gid" ]] && exit 1
+if [[ -z "$RENDER_GID" ]]; then
+  RENDER_GID=$(stat -c "%g" /dev/dri/render* | tail -n 1)
+  # is /dev/dri passed to the container?
+  [[ -z "$RENDER_GID" ]] && exit 1
+fi
 
 # note that this could conceivably be a security risk...
 cnt_group=$(getent group "$RENDER_GID" | cut -d: -f1)

--- a/.docker/base/add-render-group.sh
+++ b/.docker/base/add-render-group.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# if no var is passed, noop
+[[ -z "$RENDER_GID" ]] && exit 0
+
+cnt_gid=$(getent group render | cut -d: -f3)
+[[ -z "$cnt_gid" ]] && exit 1
+
+# note that this could conceivably be a security risk...
+cnt_group=$(getent group "$RENDER_GID" | cut -d: -f1)
+if [[ -z "$cnt_group" ]]; then
+  groupadd -g "$RENDER_GID" nekorender
+  cnt_group=nekorender
+fi
+usermod -a -G "$cnt_group" "$USER"

--- a/.docker/base/supervisord.conf
+++ b/.docker/base/supervisord.conf
@@ -9,6 +9,19 @@ loglevel=debug
 [include]
 files=/etc/neko/supervisord/*.conf
 
+[program:rendergroup-init]
+environment=RENDER_GID="%(ENV_RENDER_GID)s",USER="%(ENV_USER)s"
+command=/usr/bin/add-render-group.sh
+startsecs=0
+startretries=0
+autorestart=false
+priority=10
+user=root
+stdout_logfile=/var/log/neko/rendergroup.log
+stdout_logfile_maxbytes=1MB
+stdout_logfile_backups=10
+redirect_stderr=true
+
 [program:dbus]
 environment=HOME="/root",USER="root"
 command=/usr/bin/dbus

--- a/.docker/base/supervisord.conf
+++ b/.docker/base/supervisord.conf
@@ -33,7 +33,7 @@ redirect_stderr=true
 
 [program:pulseaudio]
 environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY="%(ENV_DISPLAY)s"
-command=/usr/bin/pulseaudio --disallow-module-loading -vvvv --disallow-exit --exit-idle-time=-1 
+command=/usr/bin/pulseaudio --disallow-module-loading -vvvv --disallow-exit --exit-idle-time=-1
 autorestart=true
 priority=300
 user=%(ENV_USER)s

--- a/server/internal/remote/manager.go
+++ b/server/internal/remote/manager.go
@@ -147,6 +147,7 @@ func (manager *RemoteManager) createPipelines() {
 		manager.config.VideoParams,
 		rate,
 		manager.config.VideoBitrate,
+		manager.config.VideoHWEnc,
 	)
 	if err != nil {
 		manager.logger.Panic().Err(err).Msg("unable to create video pipeline")
@@ -158,6 +159,7 @@ func (manager *RemoteManager) createPipelines() {
 		manager.config.AudioParams,
 		0, // fps: n/a for audio
 		manager.config.AudioBitrate,
+		"", // hwenc: n/a for audio
 	)
 	if err != nil {
 		manager.logger.Panic().Err(err).Msg("unable to create audio pipeline")
@@ -197,6 +199,7 @@ func (manager *RemoteManager) ChangeResolution(width int, height int, rate int) 
 		manager.config.VideoParams,
 		rate,
 		manager.config.VideoBitrate,
+		manager.config.VideoHWEnc,
 	)
 	if err != nil {
 		manager.logger.Panic().Err(err).Msg("unable to create new video pipeline")

--- a/server/internal/types/config/remote.go
+++ b/server/internal/types/config/remote.go
@@ -14,6 +14,7 @@ type Remote struct {
 	AudioCodec   string
 	AudioParams  string
 	AudioBitrate uint
+	VideoHWEnc   string
 	VideoCodec   string
 	VideoParams  string
 	VideoBitrate uint
@@ -64,6 +65,12 @@ func (Remote) Init(cmd *cobra.Command) error {
 		return err
 	}
 
+	// hw encoding
+	cmd.PersistentFlags().String("hwenc", "", "use hardware accelerated encoding")
+	if err := viper.BindPFlag("hwenc", cmd.PersistentFlags().Lookup("hwenc")); err != nil {
+		return err
+	}
+
 	// video codecs
 	cmd.PersistentFlags().Bool("vp8", false, "use VP8 video codec")
 	if err := viper.BindPFlag("vp8", cmd.PersistentFlags().Lookup("vp8")); err != nil {
@@ -105,15 +112,6 @@ func (Remote) Init(cmd *cobra.Command) error {
 }
 
 func (s *Remote) Set() {
-	videoCodec := "VP8"
-	if viper.GetBool("vp8") {
-		videoCodec = "VP8"
-	} else if viper.GetBool("vp9") {
-		videoCodec = "VP9"
-	} else if viper.GetBool("h264") {
-		videoCodec = "H264"
-	}
-
 	audioCodec := "Opus"
 	if viper.GetBool("opus") {
 		audioCodec = "Opus"
@@ -129,7 +127,21 @@ func (s *Remote) Set() {
 	s.AudioCodec = audioCodec
 	s.AudioParams = viper.GetString("audio")
 	s.AudioBitrate = viper.GetUint("audio_bitrate")
+
+	videoCodec := "VP8"
+	if viper.GetBool("vp8") {
+		videoCodec = "VP8"
+	} else if viper.GetBool("vp9") {
+		videoCodec = "VP9"
+	} else if viper.GetBool("h264") {
+		videoCodec = "H264"
+	}
+	videoHWEnc := ""
+	if viper.GetString("hwenc") == "VAAPI" {
+		videoHWEnc = "VAAPI"
+	}
 	s.Display = viper.GetString("display")
+	s.VideoHWEnc = videoHWEnc
 	s.VideoCodec = videoCodec
 	s.VideoParams = viper.GetString("video")
 	s.VideoBitrate = viper.GetUint("video_bitrate")


### PR DESCRIPTION
Hardware accelerated encoding using Intel QuickSync via VAAPI. Tested VP8 and H264 on a Coffee Lake CPU. 

Adding support for AMD/VAAPI *should* AFAICT just be a matter of further adding the necessary packages. The PR leaves open the possibility of adding NVENC down the line - the hw encoder to use is requested via env var.

The end user is required to (via docker-compose or whatever else):
1. pass `/dev/dri` to the container
2. pass an env var `NEKO_HWENC=VAAPI`
3. optionally pass an env var `RENDER_GID=<gid>` with the group id of the render user (or the user that owns `/dev/dri/renderD*`) - it'll be fetched automatically otherwise (as long as `/dev/dri` is passed through) but it's not well tested yet

#### Notes
*Sometimes* on container startup X will throw a fit with (possibly non-exhaustive list):
- `Xorg: ../../../../../../include/privates.h:121: dixGetPrivateAddr: Assertion 'key->initialized' failed.`
-  `Xorg: ../../../../dix/privates.c:384: dixRegisterPrivateKey: Assertion '!global_keys[type].created' failed.`

as soon as neko starts (and then neko itself dies). When that happens supervisord will restart both and soon enough they'll both manage to say alive and settle down. 
Looking for clues reveals a bunch of long-standing X bugs with a bunch of supposed patches and the general advice of "start X as root kthx" (which is *not* the case in neko, as it stands).

All it seems to do in practice is delay startup by 2-3 seconds, but it's worth keeping in mind AND testing. From the looks of it, it might be just a case of reordering/delaying stuff at startup, but *I* am not going to touch supervisord.
