### PR TITLE
Add I don't care about cookies extension

### DIFF
--- a/.docker/brave/policies.json
+++ b/.docker/brave/policies.json
@@ -24,11 +24,13 @@
   ],
   "ExtensionInstallForcelist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm;https://clients2.google.com/service/update2/crx",
-      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx"
+      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx",
+      "fihnjjcciajhdojfnbdddfaoknhalnja;https://clients2.google.com/service/update2/crx"
   ],
   "ExtensionInstallAllowlist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-      "mnjggcdmjocbbbhaepdhchncahnbgone"
+      "mnjggcdmjocbbbhaepdhchncahnbgone",
+      "fihnjjcciajhdojfnbdddfaoknhalnja"
   ],
   "ExtensionInstallBlocklist": [
       "*"

--- a/.docker/brave/preferences.json
+++ b/.docker/brave/preferences.json
@@ -8,6 +8,10 @@
     "initialized": true,
     "list": [
       {
+        "title": "Google",
+        "url": "https://www.google.com/"
+      },
+      {
         "title": "YouTube",
         "url": "https://www.youtube.com/"
       },
@@ -21,7 +25,11 @@
       },
       {
         "title": "9Anime",
-        "url": "https://9anime.to/"
+        "url": "https://9anime.pl/"
+      },
+      {
+        "title": "AniMixPlay",
+        "url": "https://animixplay.to/"
       },
       {
         "title": "Crunchy Roll",
@@ -52,8 +60,8 @@
         "url": "https://www.twitch.tv/"
       },
       {
-        "title": "Mixer",
-        "url": "https://mixer.com/"
+        "title": "Facebook Gaming",
+        "url": "https://www.facebook.com/gaming/"
       }
     ]
   },

--- a/.docker/chromium/policies.json
+++ b/.docker/chromium/policies.json
@@ -25,11 +25,13 @@
   ],
   "ExtensionInstallForcelist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm;https://clients2.google.com/service/update2/crx",
-      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx"
+      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx",
+      "fihnjjcciajhdojfnbdddfaoknhalnja;https://clients2.google.com/service/update2/crx"
   ],
   "ExtensionInstallAllowlist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-      "mnjggcdmjocbbbhaepdhchncahnbgone"
+      "mnjggcdmjocbbbhaepdhchncahnbgone",
+      "fihnjjcciajhdojfnbdddfaoknhalnja"
   ],
   "ExtensionInstallBlocklist": [
       "*"

--- a/.docker/chromium/preferences.json
+++ b/.docker/chromium/preferences.json
@@ -8,6 +8,10 @@
     "initialized": true,
     "list": [
       {
+        "title": "Google",
+        "url": "https://www.google.com/"
+      },
+      {
         "title": "YouTube",
         "url": "https://www.youtube.com/"
       },
@@ -21,7 +25,11 @@
       },
       {
         "title": "9Anime",
-        "url": "https://9anime.to/"
+        "url": "https://9anime.pl/"
+      },
+      {
+        "title": "AniMixPlay",
+        "url": "https://animixplay.to/"
       },
       {
         "title": "Crunchy Roll",
@@ -52,8 +60,8 @@
         "url": "https://www.twitch.tv/"
       },
       {
-        "title": "Mixer",
-        "url": "https://mixer.com/"
+        "title": "Facebook Gaming",
+        "url": "https://www.facebook.com/gaming/"
       }
     ]
   },

--- a/.docker/firefox/Dockerfile.arm
+++ b/.docker/firefox/Dockerfile.arm
@@ -11,6 +11,7 @@ RUN set -eux; apt-get update; \
     mkdir -p /usr/lib/firefox-esr/distribution/extensions; \
     wget -O '/usr/lib/firefox-esr/distribution/extensions/uBlock0@raymondhill.net.xpi' https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi; \
     wget -O '/usr/lib/firefox-esr/distribution/extensions/sponsorBlocker@ajay.app.xpi' https://addons.mozilla.org/firefox/downloads/latest/sponsorblock/latest.xpi; \
+    wget -O '/usr/lib/firefox-esr/distribution/extensions/iDontCareAboutCookies@i-dont-care-about-cookies.eu.xpi' https://addons.mozilla.org/firefox/downloads/latest/i-dont-care-about-cookies/latest.xpi; \
     #
     # create a profile directory
     mkdir -p /home/neko/.mozilla/firefox/profile.default/extensions; \

--- a/.docker/firefox/neko.js
+++ b/.docker/firefox/neko.js
@@ -25,7 +25,7 @@ lockPref("browser.safebrowsing.downloads.remote.enabled",	false);
 lockPref("browser.helperApps.alwaysAsk.force",	false);
 lockPref("browser.helperApps.neverAsk.saveToDisk",	"application/zip,application/octet-stream,image/jpeg,application/vnd.ms-outlook,text/html,application/pdf");
 lockPref("browser.helperApps.neverAsk.openFile",	"application/zip,application/octet-stream,image/jpeg,application/vnd.ms-outlook,text/html,application/pdf");
-lockPref("browser.newtabpage.activity-stream.default.sites",	"https://ipleak.net/,https://www.youtube.com/,https://www.google.com/");
+lockPref("browser.newtabpage.activity-stream.default.sites",	"https://www.google.com/,https://www.youtube.com/,https://netflix.com,https://www.hulu.com/,https://9anime.pl/,https://animixplay.to/,https://www.crunchyroll.com/,https://www.funimation.com/,https://www.disneyplus.com/,https://play.hbonow.com/,https://www.amazon.com/Amazon-Video/b?node=2858778011,https://vrv.co/,https://www.twitch.tv/,https://www.facebook.com/gaming/");
 // dark mode
 lockPref("reader.color_scheme", "dark");
 lockPref("devtools.theme", "dark");

--- a/.docker/firefox/policies.json
+++ b/.docker/firefox/policies.json
@@ -6,9 +6,9 @@
     "BlockAboutSupport": true,
     "Bookmarks": [
       {
-        "Title": "IPLeak",
-        "URL": "https://ipleak.net/",
-        "Favicon": "https://ipleak.net/favicon.ico",
+        "Title": "Google",
+        "URL": "https://www.google.com/",
+        "Favicon": "https://www.google.com/favicon.ico",
         "Folder": "Pages",
         "Placement": "toolbar"
       },
@@ -20,9 +20,86 @@
         "Placement": "toolbar"
       },
       {
-        "Title": "Google",
-        "URL": "https://www.google.com/",
-        "Favicon": "https://www.google.com/favicon.ico",
+        "Title": "Netflix",
+        "URL": "https://netflix.com",
+        "Favicon": "https://netflix.com/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Hulu",
+        "URL": "https://www.hulu.com/",
+        "Favicon": "https://www.hulu.com/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "9Anime",
+        "URL": "https://9anime.pl/",
+        "Favicon": "https://s2.bunnycdn.ru/assets/sites/9anime/icons/favicon.png",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "AniMixPlay",
+        "URL": "https://animixplay.to/",
+        "Favicon": "https://animixplay.to/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Crunchy Roll",
+        "URL": "https://www.crunchyroll.com/",
+        "Favicon": "https://www.crunchyroll.com/favicons/apple-touch-icon.png",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Funimation",
+        "URL": "https://www.funimation.com/",
+        "Favicon": "https://www.funimation.com/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Disney+",
+        "URL": "https://www.disneyplus.com/",
+        "Favicon": "https://www.disneyplus.com/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "HBO Now",
+        "URL": "https://play.hbonow.com/",
+        "Favicon": "https://play.hbonow.com/assets/images/branding/desktop/hbonow/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Amazon Video",
+        "URL": "https://www.amazon.com/Amazon-Video/b?node=2858778011",
+        "Favicon": "https://www.amazon.com/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "VRV",
+        "URL": "https://vrv.co/",
+        "Favicon": "https://static.vrv.co/vrvweb/assets/img/favicons/favicon-96x96.png",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Twitch",
+        "URL": "https://www.twitch.tv/",
+        "Favicon": "https://twitch.tv/favicon.ico",
+        "Folder": "Pages",
+        "Placement": "toolbar"
+      },
+      {
+        "Title": "Facebook Gaming",
+        "URL": "https://www.facebook.com/gaming/",
+        "Favicon": "https://www.facebook.com/favicon.ico",
         "Folder": "Pages",
         "Placement": "toolbar"
       }

--- a/.docker/firefox/policies.json
+++ b/.docker/firefox/policies.json
@@ -63,6 +63,10 @@
       "uBlock0@raymondhill.net": {
         "install_url": "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi",
         "installation_mode": "force_installed"
+      },
+      "iDontCareAboutCookies@i-dont-care-about-cookies.eu": {
+        "install_url": "https://addons.mozilla.org/firefox/downloads/latest/i-dont-care-about-cookies/latest.xpi",
+        "installation_mode": "force_installed"
       }
     },
     "ExtensionUpdate": false,

--- a/.docker/google-chrome/policies.json
+++ b/.docker/google-chrome/policies.json
@@ -24,11 +24,13 @@
   ],
   "ExtensionInstallForcelist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm;https://clients2.google.com/service/update2/crx",
-      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx"
+      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx",
+      "fihnjjcciajhdojfnbdddfaoknhalnja;https://clients2.google.com/service/update2/crx"
   ],
   "ExtensionInstallAllowlist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-      "mnjggcdmjocbbbhaepdhchncahnbgone"
+      "mnjggcdmjocbbbhaepdhchncahnbgone",
+      "fihnjjcciajhdojfnbdddfaoknhalnja"
   ],
   "ExtensionInstallBlocklist": [
       "*"

--- a/.docker/google-chrome/preferences.json
+++ b/.docker/google-chrome/preferences.json
@@ -8,6 +8,10 @@
     "initialized": true,
     "list": [
       {
+        "title": "Google",
+        "url": "https://www.google.com/"
+      },
+      {
         "title": "YouTube",
         "url": "https://www.youtube.com/"
       },
@@ -21,7 +25,11 @@
       },
       {
         "title": "9Anime",
-        "url": "https://9anime.to/"
+        "url": "https://9anime.pl/"
+      },
+      {
+        "title": "AniMixPlay",
+        "url": "https://animixplay.to/"
       },
       {
         "title": "Crunchy Roll",
@@ -52,8 +60,8 @@
         "url": "https://www.twitch.tv/"
       },
       {
-        "title": "Mixer",
-        "url": "https://mixer.com/"
+        "title": "Facebook Gaming",
+        "url": "https://www.facebook.com/gaming/"
       }
     ]
   },

--- a/.docker/microsoft-edge/policies.json
+++ b/.docker/microsoft-edge/policies.json
@@ -24,11 +24,13 @@
   ],
   "ExtensionInstallForcelist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm;https://clients2.google.com/service/update2/crx",
-      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx"
+      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx",
+      "fihnjjcciajhdojfnbdddfaoknhalnja;https://clients2.google.com/service/update2/crx"
   ],
   "ExtensionInstallAllowlist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-      "mnjggcdmjocbbbhaepdhchncahnbgone"
+      "mnjggcdmjocbbbhaepdhchncahnbgone",
+      "fihnjjcciajhdojfnbdddfaoknhalnja"
   ],
   "ExtensionInstallBlocklist": [
       "*"

--- a/.docker/microsoft-edge/preferences.json
+++ b/.docker/microsoft-edge/preferences.json
@@ -8,6 +8,10 @@
     "initialized": true,
     "list": [
       {
+        "title": "Google",
+        "url": "https://www.google.com/"
+      },
+      {
         "title": "YouTube",
         "url": "https://www.youtube.com/"
       },
@@ -21,7 +25,11 @@
       },
       {
         "title": "9Anime",
-        "url": "https://9anime.to/"
+        "url": "https://9anime.pl/"
+      },
+      {
+        "title": "AniMixPlay",
+        "url": "https://animixplay.to/"
       },
       {
         "title": "Crunchy Roll",
@@ -52,8 +60,8 @@
         "url": "https://www.twitch.tv/"
       },
       {
-        "title": "Mixer",
-        "url": "https://mixer.com/"
+        "title": "Facebook Gaming",
+        "url": "https://www.facebook.com/gaming/"
       }
     ]
   },

--- a/.docker/ungoogled-chromium/Dockerfile
+++ b/.docker/ungoogled-chromium/Dockerfile
@@ -33,6 +33,7 @@ RUN set -eux; apt-get update; \
     EXTENSIONS=( \
       cjpalhdlnbpafiamejdnhcphjbkeiagm \
       mnjggcdmjocbbbhaepdhchncahnbgone \
+      fihnjjcciajhdojfnbdddfaoknhalnja \
     ); \
     mkdir -p "${EXTENSIONS_DIR}"; \
     for EXT_ID in "${EXTENSIONS[@]}"; \

--- a/.docker/ungoogled-chromium/policies.json
+++ b/.docker/ungoogled-chromium/policies.json
@@ -24,7 +24,8 @@
   ],
   "ExtensionInstallAllowlist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-      "mnjggcdmjocbbbhaepdhchncahnbgone"
+      "mnjggcdmjocbbbhaepdhchncahnbgone",
+      "fihnjjcciajhdojfnbdddfaoknhalnja"
   ],
   "ExtensionInstallBlocklist": [
       "*"

--- a/.docker/ungoogled-chromium/preferences.json
+++ b/.docker/ungoogled-chromium/preferences.json
@@ -8,6 +8,10 @@
     "initialized": true,
     "list": [
       {
+        "title": "Google",
+        "url": "https://www.google.com/"
+      },
+      {
         "title": "YouTube",
         "url": "https://www.youtube.com/"
       },
@@ -21,7 +25,11 @@
       },
       {
         "title": "9Anime",
-        "url": "https://9anime.to/"
+        "url": "https://9anime.pl/"
+      },
+      {
+        "title": "AniMixPlay",
+        "url": "https://animixplay.to/"
       },
       {
         "title": "Crunchy Roll",
@@ -52,8 +60,8 @@
         "url": "https://www.twitch.tv/"
       },
       {
-        "title": "Mixer",
-        "url": "https://mixer.com/"
+        "title": "Facebook Gaming",
+        "url": "https://www.facebook.com/gaming/"
       }
     ]
   },

--- a/.docker/vivaldi/Dockerfile
+++ b/.docker/vivaldi/Dockerfile
@@ -18,6 +18,7 @@ RUN set -eux; apt-get update; \
     EXTENSIONS=( \
       cjpalhdlnbpafiamejdnhcphjbkeiagm \
       mnjggcdmjocbbbhaepdhchncahnbgone \
+      fihnjjcciajhdojfnbdddfaoknhalnja \
     ); \
     mkdir -p "${EXTENSIONS_DIR}"; \
     for EXT_ID in "${EXTENSIONS[@]}"; \

--- a/.docker/vivaldi/policies.json
+++ b/.docker/vivaldi/policies.json
@@ -24,11 +24,13 @@
   ],
   "ExtensionInstallForcelist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm;https://clients2.google.com/service/update2/crx",
-      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx"
+      "mnjggcdmjocbbbhaepdhchncahnbgone;https://clients2.google.com/service/update2/crx",
+      "fihnjjcciajhdojfnbdddfaoknhalnja;https://clients2.google.com/service/update2/crx"
   ],
   "ExtensionInstallAllowlist": [
       "cjpalhdlnbpafiamejdnhcphjbkeiagm",
-      "mnjggcdmjocbbbhaepdhchncahnbgone"
+      "mnjggcdmjocbbbhaepdhchncahnbgone",
+      "fihnjjcciajhdojfnbdddfaoknhalnja"
   ],
   "ExtensionInstallBlocklist": [
       "*"

--- a/.docker/vivaldi/preferences.json
+++ b/.docker/vivaldi/preferences.json
@@ -8,6 +8,10 @@
     "initialized": true,
     "list": [
       {
+        "title": "Google",
+        "url": "https://www.google.com/"
+      },
+      {
         "title": "YouTube",
         "url": "https://www.youtube.com/"
       },
@@ -21,7 +25,11 @@
       },
       {
         "title": "9Anime",
-        "url": "https://9anime.to/"
+        "url": "https://9anime.pl/"
+      },
+      {
+        "title": "AniMixPlay",
+        "url": "https://animixplay.to/"
       },
       {
         "title": "Crunchy Roll",
@@ -52,8 +60,8 @@
         "url": "https://www.twitch.tv/"
       },
       {
-        "title": "Mixer",
-        "url": "https://mixer.com/"
+        "title": "Facebook Gaming",
+        "url": "https://www.facebook.com/gaming/"
       }
     ]
   },


### PR DESCRIPTION
This PR is mainly for the [I don't care about cookies](https://www.i-dont-care-about-cookies.eu/) extension. It automatically hides all those annoying cookie popups on websites, which only end up getting in the way of watching videos.

Apart from that, I've made the default links/bookmarks in Firefox match the other browsers, and I've changed Mixer to Facebook gaming.