### PR TITLE
add reconnect after WebSocket Timeout(server restart)

### DIFF
--- a/client/src/components/connect.vue
+++ b/client/src/components/connect.vue
@@ -158,22 +158,22 @@
 
     mounted() {
       // auto-password fill
-      let password = this.$accessor.password
+      this.password = this.$accessor.password
       if (this.autoPassword !== null) {
         this.removeUrlParam('pwd')
-        password = this.autoPassword
+        this.password = this.autoPassword
       }
 
       // auto-user fill
-      let displayname = this.$accessor.displayname
+      this.displayname = this.$accessor.displayname
       const usr = new URL(location.href).searchParams.get('usr')
       if (usr) {
         this.removeUrlParam('usr')
-        displayname = this.$accessor.displayname || usr
+        this.displayname = this.$accessor.displayname || usr
       }
 
-      if (displayname !== '' && password !== '') {
-        this.$accessor.login({ displayname, password })
+      if (this.displayname !== '' && this.password !== '') {
+        this.$accessor.login({ displayname: this.displayname, password: this.password })
         this.autoPassword = null
       }
     }
@@ -208,7 +208,6 @@
       if (this.autoPassword !== null) {
         password = this.autoPassword
       }
-
       if (this.displayname == '') {
         this.$swal({
           title: this.$t('connect.error') as string,

--- a/client/src/neko/base.ts
+++ b/client/src/neko/base.ts
@@ -173,7 +173,7 @@ export abstract class BaseClient extends EventEmitter<BaseEvents> {
     }
 
     // @ts-ignore
-    if (typeof buffer !== 'undefined') {
+    if (typeof buffer !== 'undefined' && this._channel?.readyState == 'open') {
       this._channel!.send(buffer)
     }
   }

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -85,7 +85,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
   }
 
   protected [EVENT.CONNECTING]() {
-    this.$accessor.setConnnecting()
+    this.$accessor.setConnecting()
   }
 
   protected [EVENT.CONNECTED]() {
@@ -117,6 +117,11 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       duration: 5000,
       speed: 1000,
     })
+    if (reason?.message == 'connection timeout') {
+      if (this.$accessor.displayname && this.$accessor.password) {
+        this.login(this.$accessor.password, this.$accessor.displayname)
+      }
+    }
   }
 
   protected [EVENT.TRACK](event: RTCTrackEvent) {
@@ -160,6 +165,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       text: message,
       icon: 'error',
       confirmButtonText: this.$vue.$t('connection.button_confirm') as string,
+      timer: 15000,
     })
   }
 

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -41,7 +41,7 @@ export const mutations = mutationTree(state, {
     Vue.set(state.locked, resource, false)
   },
 
-  setConnnecting(state) {
+  setConnecting(state) {
     state.connected = false
     state.connecting = true
   },


### PR DESCRIPTION
and
- fix typo,
- don't send messages thru data channel is connection is not opened
see #261 for context

i try use auto login via url params. but if server is restarted then auto connect/reconnect/retry no working.
as far as i check code retry is more focused on webrtc connection not on webscoket?

on PR some changes to add reconnect when ws raport timeout. 
but i'm not sure what was  original logic in connect.vue ( members was not set in onMounted?).


also not sure if
```
if (reason?.message == 'connection timeout') {
```
is correct way to check Error.
also maybe cancel button should be added if connection is true? 