### PR TITLE
Nvidia nvenc

### DIFF
--- a/.docker/base/Dockerfile.nvidia
+++ b/.docker/base/Dockerfile.nvidia
@@ -54,7 +54,7 @@ RUN set -eux; \
 #
 # STAGE 1: SERVER
 #
-FROM golang:1.18-bullseye as server
+FROM golang:1.20-bullseye as server
 WORKDIR /src
 
 #
@@ -85,7 +85,7 @@ RUN go get -v -t -d . && go build -o bin/neko cmd/neko/main.go
 #
 # STAGE 2: CLIENT
 #
-FROM node:14-bullseye-slim as client
+FROM node:18-bullseye-slim as client
 WORKDIR /src
 
 #

--- a/server/internal/capture/pipelines.go
+++ b/server/internal/capture/pipelines.go
@@ -150,7 +150,7 @@ func NewVideoPipeline(rtpCodec codec.RTPCodec, display string, pipelineSrc strin
 				return "", err
 			}
 
-			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh264enc name=encoder preset=4 bitrate=%d rc-mode=5 ! h264parse config-interval=3 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate)
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh264enc name=encoder preset=2 bitrate=%d rc-mode=6 ! h264parse config-interval=3 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate)
 		} else {
 			// https://gstreamer.freedesktop.org/documentation/openh264/openh264enc.html?gi-language=c#openh264enc
 			// gstreamer1.0-plugins-bad

--- a/server/internal/capture/pipelines.go
+++ b/server/internal/capture/pipelines.go
@@ -150,7 +150,7 @@ func NewVideoPipeline(rtpCodec codec.RTPCodec, display string, pipelineSrc strin
 				return "", err
 			}
 
-			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh264enc name=encoder preset=5 zerolatency=1 gop-size=15 bitrate=%d rc-mode=5 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate)
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh264enc name=encoder preset=4 bitrate=%d rc-mode=5 ! h264parse config-interval=3 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate)
 		} else {
 			// https://gstreamer.freedesktop.org/documentation/openh264/openh264enc.html?gi-language=c#openh264enc
 			// gstreamer1.0-plugins-bad


### PR DESCRIPTION
Hi,

I had a similar problem with the rpi pipeline back in the day.
I added h264parse and it worked like expected.
I took every 3 seconds as a value for the refresh frame.

I changed the profile and the profile to High Quality since it should be fast enough on nvenc either way. But some experimenting could be done here.