### PR TITLE
Add check for volume parameter in URL before setting volume

### DIFF
--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -204,7 +204,9 @@
 
     @Watch('volume', { immediate: true })
     onVolume(volume: number) {
-      this.$accessor.video.setVolume(volume)
+      if (new URL(location.href).searchParams.has('volume')) {
+        this.$accessor.video.setVolume(volume)
+      }
     }
 
     @Watch('hideControls', { immediate: true })


### PR DESCRIPTION
When opening the page in a browser, before commit 98ba32c574a53d6e1f6ec2e2b3613c8a0383c830 the browser (firefox or chrome) would remember the Volume level from your previous session.

That commit added a URL parameter to set the volume using ?volume=value 

That commit causes the volume to be set to max every time the page is loaded due to the following line:
const numberParam = parseFloat(new URL(location.href).searchParams.get('volume') || '1.0')

This commit simply adds a check for the volume parameter before setting the variable, so if you don't set ?volume in the URL, it will use the last sessions value.

If any more info is needed, or a change must be made, please let me know.

