### PR TITLE
Add option to lock client remote on login

### DIFF
--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -204,7 +204,9 @@
 
     @Watch('volume', { immediate: true })
     onVolume(volume: number) {
-      this.$accessor.video.setVolume(volume)
+      if (new URL(location.href).searchParams.has('volume')) {
+        this.$accessor.video.setVolume(volume)
+      }
     }
 
     @Watch('hideControls', { immediate: true })

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -145,6 +145,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
         id: locks[resource],
       })
     }
+    this.$accessor.remote.setLocked('remote' in this.$accessor.locked && this.$accessor.locked['remote'])
   }
 
   protected [EVENT.SYSTEM.DISCONNECT]({ message }: SystemMessagePayload) {


### PR DESCRIPTION
One liner to lock client controls on join. Mostly useful when NEKO_IMPLICIT_CONTROL is set. 
Users joining will not be controlling but have the option.
In YAML:

NEKO_LOCKS: "remote"

Let me know if you don't like how I've done this.
