### PR TITLE
Fix buffer overflow in Gstreamer log function

### DIFF
--- a/server/internal/capture/gst/gst.c
+++ b/server/internal/capture/gst/gst.c
@@ -3,8 +3,8 @@
 static void gstreamer_pipeline_log(GstPipelineCtx *ctx, char* level, const char* format, ...) {
   va_list argptr;
   va_start(argptr, format);
-  char buffer[100];
-  vsprintf(buffer, format, argptr);
+  char buffer[4096];
+  vsnprintf(buffer, sizeof(buffer), format, argptr);
   va_end(argptr);
   goPipelineLog(level, buffer, ctx->pipelineId);
 }


### PR DESCRIPTION
vsprintf() is dangerous, and can overflow easily, especially with small buffers like the 100 byte one that was being used. This changes the buffer size to a more sane 4KiB, and uses vsnprintf() to automatically concatenate a large log message instead of overflowing and crashing.