### PR TITLE
Add a glib main loop to capture manager

### DIFF
--- a/server/internal/capture/gst/gst.go
+++ b/server/internal/capture/gst/gst.go
@@ -31,10 +31,27 @@ var pSerial int32
 var pipelines = make(map[int]*Pipeline)
 var pipelinesLock sync.Mutex
 var registry *C.GstRegistry
+var gMainLoop *C.GMainLoop
 
 func init() {
 	C.gst_init(nil, nil)
 	registry = C.gst_registry_get()
+}
+
+func RunMainLoop() {
+	if gMainLoop != nil {
+		return
+	}
+	gMainLoop = C.g_main_loop_new(nil, C.int(0))
+	C.g_main_loop_run(gMainLoop)
+}
+
+func QuitMainLoop() {
+	if gMainLoop == nil {
+		return
+	}
+	C.g_main_loop_quit(gMainLoop)
+	gMainLoop = nil
 }
 
 func CreatePipeline(pipelineStr string) (*Pipeline, error) {

--- a/server/internal/capture/manager.go
+++ b/server/internal/capture/manager.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"m1k1o/neko/internal/capture/gst"
 	"m1k1o/neko/internal/config"
 	"m1k1o/neko/internal/types"
 )
@@ -53,6 +54,7 @@ func (manager *CaptureManagerCtx) Start() {
 		}
 	}
 
+	go gst.RunMainLoop()
 	go func() {
 		for {
 			before, ok := <-manager.desktop.GetScreenSizeChangeChannel()
@@ -99,6 +101,8 @@ func (manager *CaptureManagerCtx) Shutdown() error {
 
 	manager.audio.shutdown()
 	manager.video.shutdown()
+
+	gst.QuitMainLoop()
 
 	return nil
 }


### PR DESCRIPTION
The gstreamer documentation is not particularly amazing on whether or not this is necessary, but it's clear that some gstreamer events will not be delivered to their handlers without a running glib loop. This runs one loop for all pipelines, which should be more than enough.

Disclaimer: This may conflict in demodesk/neko with the dragdrop feature. Anyone backporting this bug fix to that repo should investigate whether the loop created by `gtk_main()` will conflict with this one before blindly porting.

Fixes #380
Fixes #284