### PR TITLE
Update Firefox policies.json (prevent detaching tabs)

### DIFF
--- a/.docker/firefox/policies.json
+++ b/.docker/firefox/policies.json
@@ -112,7 +112,8 @@
       "extensions.getAddons.showPane": false,
       "places.history.enabled": false,
       "privacy.file_unique_origin": true,
-      "ui.key.menuAccessKeyFocuses": false
+      "ui.key.menuAccessKeyFocuses": false,
+      "browser.tabs.allowTabDetach": false
     },
     "PromptForDownloadLocation": false,
     "SanitizeOnShutdown": {


### PR DESCRIPTION
added `browser.tabs.allowTabDetach` to prevent drag-detaching tabs into seperate windows