### PR TITLE
disable textarea spellcheck (in firefox)

### DIFF
--- a/.docker/firefox/policies.json
+++ b/.docker/firefox/policies.json
@@ -112,7 +112,8 @@
       "extensions.getAddons.showPane": false,
       "places.history.enabled": false,
       "privacy.file_unique_origin": true,
-      "ui.key.menuAccessKeyFocuses": false
+      "ui.key.menuAccessKeyFocuses": false,
+      "browser.tabs.allowTabDetach": false
     },
     "PromptForDownloadLocation": false,
     "SanitizeOnShutdown": {

--- a/client/src/components/video.vue
+++ b/client/src/components/video.vue
@@ -11,6 +11,7 @@
         <textarea
           ref="overlay"
           class="overlay"
+          spellcheck="false"
           tabindex="0"
           data-gramm="false"
           :style="{ pointerEvents: hosting ? 'auto' : 'none' }"


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/a52537b3-2ef6-4639-b14f-239ee915719c)


after:
![image](https://github.com/user-attachments/assets/f96ebfe2-3b05-4098-9e0f-c6a0bd2142c2)
