### PR TITLE
feat(i18n): enhance language management by saving user preference and auto detect browser language

### DIFF
--- a/client/src/components/menu.vue
+++ b/client/src/components/menu.vue
@@ -62,6 +62,7 @@
 <script lang="ts">
   import { Component, Vue, Watch } from 'vue-property-decorator'
   import { messages } from '~/locale'
+  import { set } from '~/utils/localstorage'
 
   @Component({ name: 'neko-menu' })
   export default class extends Vue {
@@ -79,15 +80,10 @@
 
     @Watch('$i18n.locale')
     onLanguageChange(newLang: string) {
-      localStorage.setItem('neko_language', newLang)
+      set('lang', newLang)
     }
 
     mounted() {
-      const savedLang = localStorage.getItem('neko_language')
-      if (savedLang && this.langs.includes(savedLang)) {
-        this.$i18n.locale = savedLang
-      }
-
       const default_lang = new URL(location.href).searchParams.get('lang')
       if (default_lang && this.langs.includes(default_lang)) {
         this.$i18n.locale = default_lang

--- a/client/src/components/menu.vue
+++ b/client/src/components/menu.vue
@@ -60,7 +60,7 @@
 </style>
 
 <script lang="ts">
-  import { Component, Vue } from 'vue-property-decorator'
+  import { Component, Vue, Watch } from 'vue-property-decorator'
   import { messages } from '~/locale'
 
   @Component({ name: 'neko-menu' })
@@ -77,7 +77,17 @@
       this.$accessor.client.toggleAbout()
     }
 
+    @Watch('$i18n.locale')
+    onLanguageChange(newLang: string) {
+      localStorage.setItem('neko_language', newLang)
+    }
+
     mounted() {
+      const savedLang = localStorage.getItem('neko_language')
+      if (savedLang && this.langs.includes(savedLang)) {
+        this.$i18n.locale = savedLang
+      }
+
       const default_lang = new URL(location.href).searchParams.get('lang')
       if (default_lang && this.langs.includes(default_lang)) {
         this.$i18n.locale = default_lang

--- a/client/src/plugins/i18n.ts
+++ b/client/src/plugins/i18n.ts
@@ -4,8 +4,29 @@ import { messages } from '~/locale'
 
 Vue.use(VueI18n)
 
+function detectBrowserLanguage(): string {
+  const browserLang = navigator.language.toLowerCase()
+
+  const supportedLangs = Object.keys(messages)
+  console.log(supportedLangs)
+  if (supportedLangs.includes(browserLang)) {
+    return browserLang
+  }
+
+  const baseLang = browserLang.split('-')[0]
+  const matchingLang = supportedLangs.find((lang) => lang.startsWith(baseLang))
+  if (matchingLang) {
+    return matchingLang
+  }
+
+  return 'en'
+}
+
+const storedLang = localStorage.getItem('neko_language')
+const defaultLang = storedLang ?? detectBrowserLanguage()
+
 export const i18n = new VueI18n({
-  locale: 'en',
+  locale: defaultLang,
   fallbackLocale: 'en',
   messages,
 })

--- a/client/src/plugins/i18n.ts
+++ b/client/src/plugins/i18n.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import { messages } from '~/locale'
+import { get } from '~/utils/localstorage'
 
 Vue.use(VueI18n)
 
@@ -22,11 +23,8 @@ function detectBrowserLanguage(): string {
   return 'en'
 }
 
-const storedLang = localStorage.getItem('neko_language')
-const defaultLang = storedLang ?? detectBrowserLanguage()
-
 export const i18n = new VueI18n({
-  locale: defaultLang,
+  locale: get<string>('lang', detectBrowserLanguage()),
   fallbackLocale: 'en',
   messages,
 })

--- a/client/src/plugins/i18n.ts
+++ b/client/src/plugins/i18n.ts
@@ -5,11 +5,12 @@ import { get } from '~/utils/localstorage'
 
 Vue.use(VueI18n)
 
+const fallbackLocale = 'en'
+
 function detectBrowserLanguage(): string {
   const browserLang = navigator.language.toLowerCase()
 
   const supportedLangs = Object.keys(messages)
-  console.log(supportedLangs)
   if (supportedLangs.includes(browserLang)) {
     return browserLang
   }
@@ -20,11 +21,11 @@ function detectBrowserLanguage(): string {
     return matchingLang
   }
 
-  return 'en'
+  return fallbackLocale
 }
 
 export const i18n = new VueI18n({
   locale: get<string>('lang', detectBrowserLanguage()),
-  fallbackLocale: 'en',
+  fallbackLocale,
   messages,
 })


### PR DESCRIPTION
This PR adds the feature requested on https://github.com/m1k1o/neko/issues/55

- Added a watcher to save the selected language to `localStorage` on change.
- Implemented browser language detection to set the default language based on user settings or browser preferences.