### PR TITLE
Scroll to chat on mobile

### DIFF
--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -119,7 +119,7 @@
     }
   }
 
-  @media only screen and (max-width: 600px) {
+  @media only screen and (max-width: 1024px) {
     html,
     body {
       overflow-y: auto !important;

--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -120,22 +120,29 @@
   }
 
   @media only screen and (max-width: 600px) {
-    #neko.expanded {
-      .neko-main {
-        transform: translateX(calc(-100% + 65px));
+    html,
+    body {
+      overflow-y: auto !important;
+      width: auto !important;
+      height: auto !important;
+    }
 
-        video {
-          display: none;
-        }
+    body > p {
+      display: none;
+    }
+
+    #neko {
+      position: relative;
+      flex-direction: column;
+      max-height: initial !important;
+
+      .neko-main .video-container {
+        height: 100vh;
       }
 
       .neko-menu {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 65px;
-        width: calc(100% - 65px);
+        height: 100vh;
+        width: 100% !important;
       }
     }
   }

--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -136,12 +136,25 @@
       flex-direction: column;
       max-height: initial !important;
 
-      .neko-main .video-container {
+      .neko-main {
         height: 100vh;
       }
 
       .neko-menu {
         height: 100vh;
+        width: 100% !important;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 1024px) and (orientation: portrait) {
+    #neko {
+      &.expanded .neko-main {
+        height: 40vh;
+      }
+
+      &.expanded .neko-menu {
+        height: 60vh;
         width: 100% !important;
       }
     }
@@ -221,6 +234,20 @@
       if (enabled) {
         this.$accessor.video.setMuted(false)
         this.$accessor.settings.setSound(false)
+      }
+    }
+
+    @Watch('side')
+    onSide(side: boolean) {
+      if (side) {
+        console.log('side enabled')
+        // scroll to the side
+        this.$nextTick(() => {
+          const side = document.querySelector('aside')
+          if (side) {
+            side.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          }
+        })
       }
     }
 

--- a/client/src/components/connect.vue
+++ b/client/src/components/connect.vue
@@ -24,7 +24,7 @@
 
 <style lang="scss" scoped>
   .connect {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
This PR adds phone layout as suggested in https://github.com/m1k1o/neko/issues/381 with a difference, that in portrait mode, the chat will be shown onm 60% of the screen with 40% being the video.

https://github.com/user-attachments/assets/f2ddc1f0-088b-4d35-a8d0-a1c6a5fb96f3

