### PR TITLE
[WIP]: Adds streaming over WebSockets support #485

### DIFF
--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -1,7 +1,7 @@
 #
 # STAGE 1: SERVER
 #
-FROM golang:1.20-bullseye as server
+FROM golang:1.23-bookworm as server
 WORKDIR /src
 
 #
@@ -32,7 +32,7 @@ RUN ./build
 #
 # STAGE 2: CLIENT
 #
-FROM node:18-bullseye-slim as client
+FROM node:18-bookworm-slim as client
 WORKDIR /src
 
 #
@@ -48,7 +48,7 @@ RUN npm run build
 #
 # STAGE 3: RUNTIME
 #
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 #
 # avoid warnings by switching to noninteractive
@@ -131,7 +131,7 @@ COPY --from=server /src/bin/neko /usr/bin/neko
 COPY --from=client /src/dist/ /var/www
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=8 \
-    CMD wget -O - http://localhost:${NEKO_BIND#*:}/health || exit 1
+    CMD wget -O - http://localhost:$(echo $NEKO_BIND | awk -F':' '{print $2}')/health || exit 1
 
 #
 # run neko

--- a/client/src/neko/events.ts
+++ b/client/src/neko/events.ts
@@ -13,9 +13,11 @@ export const EVENT = {
     INIT: 'system/init',
     DISCONNECT: 'system/disconnect',
     ERROR: 'system/error',
+    INFO: 'system/info',
+    WARN: 'system/warn',
   },
   CLIENT: {
-    HEARTBEAT: 'client/heartbeat'
+    HEARTBEAT: 'client/heartbeat',
   },
   SIGNAL: {
     OFFER: 'signal/offer',
@@ -66,6 +68,8 @@ export const EVENT = {
     RELEASE: 'admin/release',
     GIVE: 'admin/give',
   },
+  // Add the new event for requesting WebSocket stream
+  STREAM_REQUEST_WS: 'stream/request_ws',
 } as const
 
 export type Events = typeof EVENT

--- a/client/src/store/remote.ts
+++ b/client/src/store/remote.ts
@@ -15,6 +15,8 @@ export const state = () => ({
   implicitHosting: true,
   fileTransfer: true,
   keyboardModifierState: -1,
+  streamingMode: 'webrtc' as 'webrtc' | 'websocket',
+  isWsStreamingActive: false,
 })
 
 export const getters = getterTree(state, {
@@ -42,7 +44,7 @@ export const mutations = mutationTree(state, {
     state.clipboard = clipboard
   },
 
-  setKeyboardModifierState(state, { capsLock, numLock, scrollLock }) {
+  setKeyboardModifierState(state, { capsLock, numLock, scrollLock }: { capsLock: boolean; numLock: boolean; scrollLock: boolean }) {
     state.keyboardModifierState = keyboardModifierState(capsLock, numLock, scrollLock)
   },
 
@@ -62,6 +64,14 @@ export const mutations = mutationTree(state, {
     state.id = ''
     state.clipboard = ''
     state.locked = false
+  },
+
+  setStreamingMode(state, mode: 'webrtc' | 'websocket') {
+    state.streamingMode = mode;
+  },
+
+  setWsStreamingActive(state, active: boolean) {
+    state.isWsStreamingActive = active;
   },
 })
 

--- a/server/internal/capture/manager.go
+++ b/server/internal/capture/manager.go
@@ -2,6 +2,8 @@ package capture
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -9,24 +11,38 @@ import (
 	"m1k1o/neko/internal/capture/gst"
 	"m1k1o/neko/internal/config"
 	"m1k1o/neko/internal/types"
+
+	go_gst "github.com/go-gst/go-gst/gst"
+	go_gst_app "github.com/go-gst/go-gst/gst/app"
 )
 
 type CaptureManagerCtx struct {
 	logger  zerolog.Logger
 	desktop types.DesktopManager
+	config  *config.Capture // Store main capture config
+	wsConfig *config.WebSocket // Store websocket config
 
 	// sinks
 	broadcast *BroacastManagerCtx
 	audio     *StreamSinkManagerCtx
 	video     *StreamSinkManagerCtx
+
+	// websocket fMP4 pipeline
+	wsPipeline   *gst.Pipeline
+	wsAppSink    *go_gst_app.Sink
+	wsMux        sync.Mutex
+	wsClientCnt  int
+	wsPipelineMu sync.Mutex
 }
 
-func New(desktop types.DesktopManager, config *config.Capture) *CaptureManagerCtx {
+func New(desktop types.DesktopManager, config *config.Capture, wsConfig *config.WebSocket) *CaptureManagerCtx {
 	logger := log.With().Str("module", "capture").Logger()
 
 	return &CaptureManagerCtx{
 		logger:  logger,
 		desktop: desktop,
+		config:  config,  // Store capture config
+		wsConfig: wsConfig, // Store websocket config
 
 		// sinks
 		broadcast: broadcastNew(func(url string) (string, error) {
@@ -44,6 +60,8 @@ func New(desktop types.DesktopManager, config *config.Capture) *CaptureManagerCt
 			}
 			return NewVideoPipeline(config.VideoCodec, config.Display, config.VideoPipeline, fps, config.VideoBitrate, config.VideoHWEnc)
 		}, "video"),
+
+		// ws fields initialized to zero values (nil, nil, zero mutex, 0)
 	}
 }
 
@@ -73,6 +91,10 @@ func (manager *CaptureManagerCtx) Start() {
 				if manager.broadcast.Started() {
 					manager.broadcast.destroyPipeline()
 				}
+
+				// Destroy WebSocket pipeline before screen change
+				manager.DestroyWebSocketPipeline()
+
 			} else {
 				// after screen size change, we need to recreate all pipelines
 
@@ -89,6 +111,20 @@ func (manager *CaptureManagerCtx) Start() {
 						manager.logger.Panic().Err(err).Msg("unable to recreate broadcast pipeline")
 					}
 				}
+
+				// Recreate WebSocket pipeline if clients were connected
+				manager.wsPipelineMu.Lock()
+				clientCount := manager.wsClientCnt
+				manager.wsPipelineMu.Unlock()
+
+				if clientCount > 0 {
+					manager.logger.Info().Msg("recreating WebSocket pipeline after screen change")
+					_, err := manager.EnsureWebSocketPipeline() // Recreate pipeline
+					if err != nil {
+						// TODO: Handle this more gracefully? Maybe retry?
+						manager.logger.Error().Err(err).Msg("failed to recreate WebSocket pipeline after screen change")
+					}
+				}
 			}
 		}
 	}()
@@ -101,6 +137,9 @@ func (manager *CaptureManagerCtx) Shutdown() error {
 
 	manager.audio.shutdown()
 	manager.video.shutdown()
+
+	// Destroy WebSocket pipeline on shutdown
+	manager.DestroyWebSocketPipeline()
 
 	gst.QuitMainLoop()
 
@@ -117,4 +156,111 @@ func (manager *CaptureManagerCtx) Audio() types.StreamSinkManager {
 
 func (manager *CaptureManagerCtx) Video() types.StreamSinkManager {
 	return manager.video
+}
+
+// EnsureWebSocketPipeline creates the fMP4 pipeline if it doesn't exist,
+// increments the client counter, and returns the appsink.
+func (manager *CaptureManagerCtx) EnsureWebSocketPipeline() (*go_gst_app.Sink, error) {
+	manager.wsPipelineMu.Lock()
+	defer manager.wsPipelineMu.Unlock()
+
+	if manager.wsPipeline != nil {
+		manager.wsClientCnt++
+		manager.logger.Debug().Int("count", manager.wsClientCnt).Msg("incremented WebSocket client count")
+		return manager.wsAppSink, nil
+	}
+
+	manager.logger.Info().Msg("creating WebSocket pipeline")
+
+	// Get current screen settings
+	screenSize := manager.desktop.GetScreenSize()
+	fps := screenSize.Rate
+	// if max fps is set, cap it to that value
+	if manager.config.VideoMaxFPS > 0 && manager.config.VideoMaxFPS < fps {
+		fps = manager.config.VideoMaxFPS
+	}
+
+	pipelineStr, err := NewWebSocketPipeline(
+		manager.wsConfig.VideoCodec,
+		manager.wsConfig.AudioCodec,
+		manager.config.Display,
+		manager.config.AudioDevice,
+		"", // No custom pipeline support for WS yet
+		fps,
+		manager.wsConfig.VideoBitrate,
+		manager.wsConfig.AudioBitrate,
+		manager.config.VideoHWEnc,
+		manager.wsConfig.FragmentDuration,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build WebSocket pipeline string: %w", err)
+	}
+
+	manager.wsPipeline, err = gst.CreatePipeline(pipelineStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Call the wrapper's GetAppSink (no arguments)
+	manager.wsAppSink = manager.wsPipeline.GetAppSink()
+	if manager.wsAppSink == nil {
+		manager.wsPipeline.Stop() // Stop calls Destroy internally now
+		manager.wsPipeline = nil // Stop should already delete from map, but good practice
+		return nil, fmt.Errorf("failed to get appsink element from WebSocket pipeline wrapper using Ctx field")
+	}
+
+	// Set the pipeline to playing using the wrapper's method
+	manager.wsPipeline.Play()
+
+	manager.wsClientCnt = 1
+	manager.logger.Info().Msg("WebSocket pipeline created and started")
+	return manager.wsAppSink, nil
+}
+
+// ReleaseWebSocketPipeline decrements the client counter and destroys the pipeline
+// if the counter reaches zero.
+func (manager *CaptureManagerCtx) ReleaseWebSocketPipeline() {
+	manager.wsPipelineMu.Lock()
+	defer manager.wsPipelineMu.Unlock()
+
+	if manager.wsPipeline == nil {
+		manager.logger.Warn().Msg("ReleaseWebSocketPipeline called but pipeline is already nil")
+		return
+	}
+
+	manager.wsClientCnt--
+	manager.logger.Debug().Int("count", manager.wsClientCnt).Msg("decremented WebSocket client count")
+
+	if manager.wsClientCnt <= 0 {
+		manager.logger.Info().Msg("destroying WebSocket pipeline as last client disconnected")
+		manager.destroyWebSocketPipelineInternal()
+	}
+}
+
+// DestroyWebSocketPipeline force destroys the pipeline, regardless of client count.
+// Used for shutdown and screen changes.
+func (manager *CaptureManagerCtx) DestroyWebSocketPipeline() {
+	manager.wsPipelineMu.Lock()
+	defer manager.wsPipelineMu.Unlock()
+
+	if manager.wsPipeline == nil {
+		return // Already destroyed
+	}
+
+	manager.logger.Info().Msg("force destroying WebSocket pipeline")
+	manager.destroyWebSocketPipelineInternal()
+}
+
+// destroyWebSocketPipelineInternal performs the actual destruction. MUST be called with wsPipelineMu locked.
+func (manager *CaptureManagerCtx) destroyWebSocketPipelineInternal() {
+	if manager.wsPipeline == nil {
+		return
+	}
+	// Stop now calls the C destroy function and removes from map in gst.go
+	manager.wsPipeline.Stop()
+
+	manager.wsPipeline = nil // Ensure Go reference is cleared
+	manager.wsAppSink = nil
+	manager.wsClientCnt = 0 // Reset count on force destroy
+	manager.logger.Debug().Msg("WebSocket pipeline destroyed internal")
 }

--- a/server/internal/config/websocket.go
+++ b/server/internal/config/websocket.go
@@ -18,6 +18,14 @@ type WebSocket struct {
 
 	FileTransferEnabled bool
 	FileTransferPath    string
+
+	// WebSocket Streaming Config
+	StreamingEnabled bool
+	VideoCodec       string // Preferred video codec (e.g., "h264")
+	AudioCodec       string // Preferred audio codec (e.g., "aac")
+	VideoBitrate     uint   // Video bitrate in kbps for WebSocket streaming
+	AudioBitrate     uint   // Audio bitrate in kbps for WebSocket streaming
+	FragmentDuration uint   // fMP4 fragment duration in ms
 }
 
 func (WebSocket) Init(cmd *cobra.Command) error {
@@ -58,6 +66,37 @@ func (WebSocket) Init(cmd *cobra.Command) error {
 		return err
 	}
 
+	// WebSocket Streaming Flags
+	cmd.PersistentFlags().Bool("ws_streaming", false, "enable video/audio streaming over WebSocket (fallback)")
+	if err := viper.BindPFlag("ws_streaming", cmd.PersistentFlags().Lookup("ws_streaming")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().String("ws_video_codec", "h264", "video codec for WebSocket streaming (h264)")
+	if err := viper.BindPFlag("ws_video_codec", cmd.PersistentFlags().Lookup("ws_video_codec")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().String("ws_audio_codec", "aac", "audio codec for WebSocket streaming (aac)")
+	if err := viper.BindPFlag("ws_audio_codec", cmd.PersistentFlags().Lookup("ws_audio_codec")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Uint("ws_video_bitrate", 2048, "video bitrate in kbps for WebSocket streaming")
+	if err := viper.BindPFlag("ws_video_bitrate", cmd.PersistentFlags().Lookup("ws_video_bitrate")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Uint("ws_audio_bitrate", 128, "audio bitrate in kbps for WebSocket streaming")
+	if err := viper.BindPFlag("ws_audio_bitrate", cmd.PersistentFlags().Lookup("ws_audio_bitrate")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Uint("ws_fragment_duration", 100, "fMP4 fragment duration in milliseconds for WebSocket streaming")
+	if err := viper.BindPFlag("ws_fragment_duration", cmd.PersistentFlags().Lookup("ws_fragment_duration")); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -73,4 +112,12 @@ func (s *WebSocket) Set() {
 	s.FileTransferEnabled = viper.GetBool("file_transfer_enabled")
 	s.FileTransferPath = viper.GetString("file_transfer_path")
 	s.FileTransferPath = filepath.Clean(s.FileTransferPath)
+
+	// WebSocket Streaming Config
+	s.StreamingEnabled = viper.GetBool("ws_streaming")
+	s.VideoCodec = viper.GetString("ws_video_codec")
+	s.AudioCodec = viper.GetString("ws_audio_codec")
+	s.VideoBitrate = viper.GetUint("ws_video_bitrate")
+	s.AudioBitrate = viper.GetUint("ws_audio_bitrate")
+	s.FragmentDuration = viper.GetUint("ws_fragment_duration")
 }


### PR DESCRIPTION
- Updated base images in Dockerfile to use Go 1.23 and Node 18 (bookworm).
- Added WebSocket streaming support in the client, including new methods for handling binary data and managing streaming modes.
- Introduced a new WebSocket pipeline in the server for fMP4 streaming, with configuration options for video and audio codecs, bitrates, and fragment duration.
- Enhanced the BaseClient to support streaming mode selection and improved error handling for WebSocket connections.
- Updated Vue component to integrate WebSocket streaming features and manage state accordingly.