### PR TITLE
Fix docker volume mount error in build script.

### DIFF
--- a/build
+++ b/build
@@ -313,7 +313,7 @@ fi
 
 log "Building base image: $BASE_IMAGE"
 docker run --rm -i \
-  -v ./:/src \
+  -v "$(pwd)":/src \
   -e "RUNTIME_DOCKERFILE=$RUNTIME_DOCKERFILE" \
   --workdir /src \
   --entrypoint go \


### PR DESCRIPTION
Fixing a build error -- docker does not allow mounting `./` as source volume.
```
docker: Error response from daemon: create ./: "./" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```