### PR TITLE
Fix mobile keyboard behavior

### DIFF
--- a/client/src/components/video.vue
+++ b/client/src/components/video.vue
@@ -367,12 +367,11 @@
 
     get is_touch_device() {
       return (
-        // check if the device has a touch screen
+        // detect if the device has touch support
         ('ontouchstart' in window || navigator.maxTouchPoints > 0) &&
-        // we also check if the device has a pointer
-        !window.matchMedia('(pointer:fine)').matches &&
-        // and is capable of hover, then it probably has a mouse
-        !window.matchMedia('(hover:hover)').matches
+        // the primary input mechanism includes a pointing device of
+        // limited accuracy, such as a finger on a touchscreen.
+        window.matchMedia('(pointer: coarse)').matches
       )
     }
 

--- a/client/src/components/video.vue
+++ b/client/src/components/video.vue
@@ -65,7 +65,7 @@
         <li
           v-if="hosting && is_touch_device"
           :class="extraControls || 'extra-control'"
-          @click.stop.prevent="toggleMobileKeyboard"
+          @click.stop.prevent="openMobileKeyboard"
         >
           <i class="fas fa-keyboard" />
         </li>
@@ -822,64 +822,20 @@
     @Watch('hosting')
     @Watch('locked')
     onFocus() {
+      // focus opens the keyboard on mobile
+      if (!this.is_touch_device) {
+        return
+      }
+
       // in order to capture key events, overlay must be focused
       if (this.focused && this.hosting && !this.locked) {
         this._overlay.focus()
       }
     }
 
-    //
-    // mobile keyboard
-    //
-
-    kbdShow = false
-    kbdOpen = false
-
-    showMobileKeyboard() {
-      // skip if not a touch device
-      if (!this.is_touch_device) return
-
-      this.kbdShow = true
-      this.kbdOpen = false
-
-      const overlay = this.$refs.overlay as HTMLTextAreaElement
-      overlay.focus()
-      window.visualViewport?.addEventListener('resize', this.onVisualViewportResize)
-    }
-
-    hideMobileKeyboard() {
-      // skip if not a touch device
-      if (!this.is_touch_device) return
-
-      this.kbdShow = false
-      this.kbdOpen = false
-
-      const overlay = this.$refs.overlay as HTMLTextAreaElement
-      window.visualViewport?.removeEventListener('resize', this.onVisualViewportResize)
-      overlay.blur()
-    }
-
-    toggleMobileKeyboard() {
-      // skip if not a touch device
-      if (!this.is_touch_device) return
-
-      if (this.kbdShow) {
-        this.hideMobileKeyboard()
-      } else {
-        this.showMobileKeyboard()
-      }
-    }
-
-    // visual viewport resize event is fired when keyboard is opened or closed
-    // android does not blur textarea when keyboard is closed, so we need to do it manually
-    onVisualViewportResize() {
-      if (!this.kbdShow) return
-
-      if (!this.kbdOpen) {
-        this.kbdOpen = true
-      } else {
-        this.hideMobileKeyboard()
-      }
+    openMobileKeyboard() {
+      // focus opens the keyboard on mobile
+      this._overlay.focus()
     }
   }
 </script>


### PR DESCRIPTION
To determine if user has a touch device we used:
- check for `'ontouchstart' in window` or `navigator.maxTouchPoints > 0`
- check if pointer is not [fine](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#fine).
- check if there is no hover.

There was however an issue with the last one. Some touch devices with Stylus do support hover and the keyboard icon was not shown. We would need to check if the user has no physical keyboard, rather that checking if they use touch device. But here is [no reliable way to do it](https://stackoverflow.com/questions/18880236/how-do-i-detect-hardware-keyboard-presence-with-javascript). So we removed the hover check and show the virtual keyboard button for all touch devices, even if would be touchscreens with mouse pointer and keyboard (as mentioned here https://github.com/demodesk/neko-client/pull/30).

Functions were simplified, as we only need to show the virtual keyboard (that is focusing the overlay textarea). Other logic was removed as it was causing some issues on android, mainly closing the keybaord right after it has been shown.