### PR TITLE
[WIP] Allow a user to see messages after rebooting or connecting to the room

### DIFF
--- a/client/src/components/chat.vue
+++ b/client/src/components/chat.vue
@@ -343,7 +343,7 @@
 
 <script lang="ts">
   import { Component, Ref, Watch, Vue } from 'vue-property-decorator'
-  import { formatRelative } from 'date-fns'
+  import { formatRelative, parseISO } from 'date-fns'
 
   import { Member } from '~/neko/types'
 
@@ -404,11 +404,13 @@
     }
 
     member(id: string) {
-      return this.$accessor.user.members[id] || { id, displayname: this.$t('somebody') }
+      return this.$accessor.user.members[id] || { id, displayname: id }
     }
 
-    timestamp(time: Date) {
-      const str = formatRelative(time, new Date())
+    timestamp(time: Date | string) {
+      const dateObj = typeof time === 'string' ? parseISO(time) : time
+
+      const str = formatRelative(dateObj, new Date())
       return `${str.charAt(0).toUpperCase()}${str.slice(1)}`
     }
 

--- a/client/src/neko/events.ts
+++ b/client/src/neko/events.ts
@@ -38,6 +38,7 @@ export const EVENT = {
     KEYBOARD: 'control/keyboard',
   },
   CHAT: {
+    INIT: 'chat/init',
     MESSAGE: 'chat/message',
     EMOTE: 'chat/emote',
   },
@@ -100,7 +101,7 @@ export type SignalEvents =
   | typeof EVENT.SIGNAL.PROVIDE
   | typeof EVENT.SIGNAL.CANDIDATE
 
-export type ChatEvents = typeof EVENT.CHAT.MESSAGE | typeof EVENT.CHAT.EMOTE
+export type ChatEvents = typeof EVENT.CHAT.INIT | typeof EVENT.CHAT.MESSAGE | typeof EVENT.CHAT.EMOTE
 
 export type FileTransferEvents = typeof EVENT.FILETRANSFER.LIST | typeof EVENT.FILETRANSFER.REFRESH
 

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -23,6 +23,7 @@ import {
   SystemInitPayload,
   AdminLockResource,
   FileTransferListPayload,
+  ChatInitPayload,
 } from './messages'
 
 interface NekoEvents extends BaseEvents {}
@@ -335,7 +336,22 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
   /////////////////////////////
   // Chat Events
   /////////////////////////////
-  protected [EVENT.CHAT.MESSAGE]({ id, content }: ChatPayload) {
+  protected [EVENT.CHAT.INIT]({ enabled, history }: ChatInitPayload) {
+    // Process message history if available
+    if (history && history.length > 0) {
+      // Process messages in chronological order
+      for (const message of history) {
+        this.$accessor.chat.newMessage({
+          id: message.id,
+          content: message.content,
+          type: 'text',
+          created: message.created,
+        })
+      }
+    }
+  }
+
+  protected [EVENT.CHAT.MESSAGE]({ id, content, created }: ChatPayload) {
     const member = this.member(id)
     if (!member || member.ignored) {
       return
@@ -345,7 +361,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
       id,
       content,
       type: 'text',
-      created: new Date(),
+      created: created,
     })
   }
 

--- a/client/src/neko/messages.ts
+++ b/client/src/neko/messages.ts
@@ -24,6 +24,7 @@ export type WebSocketMessages =
   | ControlMessage
   | ScreenResolutionMessage
   | ScreenConfigurationsMessage
+  | ChatInitMessage
   | ChatMessage
 
 export type WebSocketPayloads =
@@ -36,6 +37,7 @@ export type WebSocketPayloads =
   | ControlPayload
   | ControlClipboardPayload
   | ControlKeyboardPayload
+  | ChatInitPayload
   | ChatPayload
   | ChatSendPayload
   | EmojiSendPayload
@@ -168,6 +170,16 @@ export interface ControlKeyboardPayload {
 /*
   CHAT PAYLOADS
 */
+// chat/init
+export interface ChatInitMessage extends WebSocketMessage, ChatInitPayload {
+  event: typeof EVENT.CHAT.INIT
+}
+
+export interface ChatInitPayload {
+  enabled: boolean
+  history: ChatPayload[]
+}
+
 // chat/message
 export interface ChatMessage extends WebSocketMessage, ChatPayload {
   event: typeof EVENT.CHAT.MESSAGE
@@ -179,6 +191,7 @@ export interface ChatSendPayload {
 export interface ChatPayload {
   id: string
   content: string
+  created: string | Date
 }
 
 // chat/emoji

--- a/client/src/store/chat.ts
+++ b/client/src/store/chat.ts
@@ -16,7 +16,7 @@ interface Emotes {
 interface Message {
   id: string
   content: string
-  created: Date
+  created: Date | string
   type: 'text' | 'event'
 }
 

--- a/server/internal/http/legacy/event/events.go
+++ b/server/internal/http/legacy/event/events.go
@@ -1,68 +1,69 @@
 package event
 
 const (
-	SYSTEM_INIT       = "system/init"
-	SYSTEM_DISCONNECT = "system/disconnect"
-	SYSTEM_ERROR      = "system/error"
+  SYSTEM_INIT       = "system/init"
+  SYSTEM_DISCONNECT = "system/disconnect"
+  SYSTEM_ERROR      = "system/error"
 )
 
 const (
-	CLIENT_HEARTBEAT = "client/heartbeat"
+  CLIENT_HEARTBEAT = "client/heartbeat"
 )
 
 const (
-	SIGNAL_OFFER     = "signal/offer"
-	SIGNAL_ANSWER    = "signal/answer"
-	SIGNAL_PROVIDE   = "signal/provide"
-	SIGNAL_CANDIDATE = "signal/candidate"
+  SIGNAL_OFFER     = "signal/offer"
+  SIGNAL_ANSWER    = "signal/answer"
+  SIGNAL_PROVIDE   = "signal/provide"
+  SIGNAL_CANDIDATE = "signal/candidate"
 )
 
 const (
-	MEMBER_LIST         = "member/list"
-	MEMBER_CONNECTED    = "member/connected"
-	MEMBER_DISCONNECTED = "member/disconnected"
+  MEMBER_LIST         = "member/list"
+  MEMBER_CONNECTED    = "member/connected"
+  MEMBER_DISCONNECTED = "member/disconnected"
 )
 
 const (
-	CONTROL_LOCKED     = "control/locked"
-	CONTROL_RELEASE    = "control/release"
-	CONTROL_REQUEST    = "control/request"
-	CONTROL_REQUESTING = "control/requesting"
-	CONTROL_GIVE       = "control/give"
-	CONTROL_CLIPBOARD  = "control/clipboard"
-	CONTROL_KEYBOARD   = "control/keyboard"
+  CONTROL_LOCKED     = "control/locked"
+  CONTROL_RELEASE    = "control/release"
+  CONTROL_REQUEST    = "control/request"
+  CONTROL_REQUESTING = "control/requesting"
+  CONTROL_GIVE       = "control/give"
+  CONTROL_CLIPBOARD  = "control/clipboard"
+  CONTROL_KEYBOARD   = "control/keyboard"
 )
 
 const (
-	CHAT_MESSAGE = "chat/message"
-	CHAT_EMOTE   = "chat/emote"
+  CHAT_INIT    = "chat/init"
+  CHAT_MESSAGE = "chat/message"
+  CHAT_EMOTE   = "chat/emote"
 )
 
 const (
-	FILETRANSFER_LIST    = "filetransfer/list"
-	FILETRANSFER_REFRESH = "filetransfer/refresh"
+  FILETRANSFER_LIST    = "filetransfer/list"
+  FILETRANSFER_REFRESH = "filetransfer/refresh"
 )
 
 const (
-	SCREEN_CONFIGURATIONS = "screen/configurations"
-	SCREEN_RESOLUTION     = "screen/resolution"
-	SCREEN_SET            = "screen/set"
+  SCREEN_CONFIGURATIONS = "screen/configurations"
+  SCREEN_RESOLUTION     = "screen/resolution"
+  SCREEN_SET            = "screen/set"
 )
 
 const (
-	BROADCAST_STATUS  = "broadcast/status"
-	BROADCAST_CREATE  = "broadcast/create"
-	BROADCAST_DESTROY = "broadcast/destroy"
+  BROADCAST_STATUS  = "broadcast/status"
+  BROADCAST_CREATE  = "broadcast/create"
+  BROADCAST_DESTROY = "broadcast/destroy"
 )
 
 const (
-	ADMIN_BAN     = "admin/ban"
-	ADMIN_KICK    = "admin/kick"
-	ADMIN_LOCK    = "admin/lock"
-	ADMIN_MUTE    = "admin/mute"
-	ADMIN_UNLOCK  = "admin/unlock"
-	ADMIN_UNMUTE  = "admin/unmute"
-	ADMIN_CONTROL = "admin/control"
-	ADMIN_RELEASE = "admin/release"
-	ADMIN_GIVE    = "admin/give"
+  ADMIN_BAN     = "admin/ban"
+  ADMIN_KICK    = "admin/kick"
+  ADMIN_LOCK    = "admin/lock"
+  ADMIN_MUTE    = "admin/mute"
+  ADMIN_UNLOCK  = "admin/unlock"
+  ADMIN_UNMUTE  = "admin/unmute"
+  ADMIN_CONTROL = "admin/control"
+  ADMIN_RELEASE = "admin/release"
+  ADMIN_GIVE    = "admin/give"
 )

--- a/server/internal/http/legacy/message/messages.go
+++ b/server/internal/http/legacy/message/messages.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"github.com/m1k1o/neko/server/internal/http/legacy/types"
+	"time"
 
 	"github.com/pion/webrtc/v3"
 )
@@ -91,10 +92,16 @@ type ChatReceive struct {
 	Content string `json:"content"`
 }
 
+type ChatInit struct {
+	Event   string     `json:"event"`
+	Enabled bool       `json:"enabled"`
+	History []ChatSend `json:"history"`
+}
 type ChatSend struct {
-	Event   string `json:"event"`
-	ID      string `json:"id"`
-	Content string `json:"content"`
+	Event   string    `json:"event"`
+	ID      string    `json:"id"`
+	Content string    `json:"content"`
+	Created time.Time `json:"created"`
 }
 
 type EmoteReceive struct {

--- a/server/internal/plugins/chat/types.go
+++ b/server/internal/plugins/chat/types.go
@@ -10,7 +10,8 @@ const (
 )
 
 type Init struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool      `json:"enabled"`
+	History []Message `json:"history"`
 }
 
 type Content struct {


### PR DESCRIPTION
 - Introduce a message history in the chat manager to store the last 100 messages and include it in the chat initialization payload.
 - Update the client to process and display chat history during initialization.
 - Update legacy handler and events to support it