### PR TITLE
Upgrade bookworm

### DIFF
--- a/build
+++ b/build
@@ -318,6 +318,6 @@ docker run --rm -i \
   -e "RUNTIME_DOCKERFILE=$RUNTIME_DOCKERFILE" \
   --workdir /src \
   --entrypoint go \
-  golang:1.24-bullseye \
+  golang:1.24-bookworm \
   run utils/docker/main.go \
   -i Dockerfile.tmpl -client "$CLIENT_DIST" | build_image $BASE_IMAGE -f - .

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=node:18-bullseye-slim
+ARG BASE_IMAGE=node:18-bookworm-slim
 FROM $BASE_IMAGE AS client
 
 WORKDIR /src

--- a/runtime/Dockerfile.bookworm
+++ b/runtime/Dockerfile.bookworm
@@ -14,7 +14,7 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         wget ca-certificates supervisor \
-        pulseaudio xserver-xorg-video-dummy \
+        pulseaudio dbus-x11 xserver-xorg-video-dummy \
         libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx7 libxcvt0 \
         #
         # needed for profile upload preStop hook
@@ -72,9 +72,12 @@ RUN set -eux; \
 #
 # copy runtime configs
 COPY --chown=neko:neko .Xresources /home/$USERNAME/.Xresources
+COPY dbus /usr/bin/dbus
 COPY default.pa /etc/pulse/default.pa
 COPY supervisord.conf /etc/neko/supervisord.conf
+COPY supervisord.dbus.conf /etc/neko/supervisord.dbus.conf
 COPY xorg.conf /etc/neko/xorg.conf
+RUN chmod 0700 /tmp/runtime-neko
 
 #
 # copy runtime folders
@@ -95,8 +98,8 @@ ENV NEKO_PLUGINS_DIR=/etc/neko/plugins/
 #
 # add healthcheck
 HEALTHCHECK --interval=10s --timeout=5s --retries=8 \
-    CMD wget -O - http://localhost:${NEKO_SERVER_BIND#*:}/health || \
-        wget --no-check-certificate -O - https://localhost:${NEKO_SERVER_BIND#*:}/health || \
+    CMD wget -O - http://localhost:8080/health || \
+        wget --no-check-certificate -O - https://localhost:8080/health || \
         exit 1
 #
 # run neko

--- a/utils/xorg-deps/Dockerfile
+++ b/utils/xorg-deps/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:bullseye-slim
+ARG BASE_IMAGE=debian:bookworm-slim
 FROM $BASE_IMAGE AS xorg-deps
 
 WORKDIR /xorg

--- a/utils/xorg-deps/xf86-input-neko/Dockerfile
+++ b/utils/xorg-deps/xf86-input-neko/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
- I tried to make as small changes as possible.
- I tested 3 apps:
  - KDE works.
  - VLC works.
  - **Chromium broken**.

Build:
```
./build --flavor bookworm
./build --application kde --base_image ghcr.io/m1k1o/neko/bookworm-base:latest

docker run -p 8080:8080 -p 52000-52100:52000-52100/udp --shm-size=2gb ghcr.io/m1k1o/neko/kde
```