### PR TITLE
Add hostname to broadcast variables

### DIFF
--- a/server/internal/capture/manager.go
+++ b/server/internal/capture/manager.go
@@ -3,6 +3,7 @@ package capture
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -80,6 +81,10 @@ func New(desktop types.DesktopManager, config *config.Capture) *CaptureManagerCt
 		broadcast: broadcastNew(func(url string) (string, error) {
 			if config.BroadcastPipeline != "" {
 				var pipeline = config.BroadcastPipeline
+				if hostname, err := os.Hostname(); err == nil {
+					// replace {hostname} with valid hostname
+					pipeline = strings.Replace(pipeline, "{hostname}", hostname, 1)
+				}
 				// replace {display} with valid display
 				pipeline = strings.Replace(pipeline, "{display}", config.Display, 1)
 				// replace {device} with valid device

--- a/server/internal/config/capture.go
+++ b/server/internal/config/capture.go
@@ -298,7 +298,7 @@ func (Capture) InitV2(cmd *cobra.Command) error {
 	// broadcast
 	//
 
-	cmd.PersistentFlags().String("broadcast_pipeline", "", "V2: custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced")
+	cmd.PersistentFlags().String("broadcast_pipeline", "", "V2: custom gst pipeline used for broadcasting, strings {hostname} {url} {device} {display} will be replaced")
 	if err := viper.BindPFlag("broadcast_pipeline", cmd.PersistentFlags().Lookup("broadcast_pipeline")); err != nil {
 		return err
 	}

--- a/server/internal/config/capture_pipeline.go
+++ b/server/internal/config/capture_pipeline.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/m1k1o/neko/server/pkg/gst"
@@ -40,12 +41,17 @@ func NewBroadcastPipeline(device string, display string, pipelineSrc string, url
 
 	var pipelineStr string
 	if pipelineSrc != "" {
+		pipelineStr = pipelineSrc
+		// replace {hostname} with valid hostname
+		if hostname, err := os.Hostname(); err == nil {
+			pipelineStr = strings.ReplaceAll(pipelineStr, "{hostname}", hostname)
+		}
 		// replace RTMP url
-		pipelineStr = strings.Replace(pipelineSrc, "{url}", url, -1)
+		pipelineStr = strings.ReplaceAll(pipelineStr, "{url}", url)
 		// replace audio device
-		pipelineStr = strings.Replace(pipelineStr, "{device}", device, -1)
+		pipelineStr = strings.ReplaceAll(pipelineStr, "{device}", device)
 		// replace display
-		pipelineStr = strings.Replace(pipelineStr, "{display}", display, -1)
+		pipelineStr = strings.ReplaceAll(pipelineStr, "{display}", display)
 	} else {
 		pipelineStr = fmt.Sprintf("flvmux name=mux ! rtmpsink location='%s live=1' %s audio/x-raw,channels=2 ! audioconvert ! voaacenc ! mux. %s x264enc bframes=0 key-int-max=60 byte-stream=true tune=zerolatency speed-preset=veryfast ! mux.", url, audio, video)
 	}

--- a/webpage/docs/configuration/capture.md
+++ b/webpage/docs/configuration/capture.md
@@ -347,7 +347,7 @@ The default encoder uses `h264` for video and `aac` for audio, muxed in the `flv
 
 - <Def id="broadcast.audio_bitrate" /> and <Def id="broadcast.video_bitrate" /> are the bitrate settings for the default audio and video encoders expressed in kilobits per second.
 - <Def id="broadcast.preset" /> is the encoding speed preset for the default video encoder. See available presets [here](https://gstreamer.freedesktop.org/documentation/x264/index.html?gi-language=c#GstX264EncPreset).
-- <Def id="broadcast.pipeline" /> when set, encoder settings above are ignored and the custom Gstreamer pipeline description is used. In the pipeline, you can use `{display}`, `{device}` and `{url}` as placeholders for the X display name, pulseaudio audio device name, and broadcast URL respectively.
+- <Def id="broadcast.pipeline" /> when set, encoder settings above are ignored and the custom Gstreamer pipeline description is used. In the pipeline, you can use `{hostname}`, `{display}`, `{device}` and `{url}` as placeholders for the X display name, pulseaudio audio device name, and broadcast URL respectively.
 - <Def id="broadcast.url" /> is the URL of the RTMP server where the broadcast will be sent e.g. `rtmp://<server>/<application>/<stream_key>`. This can be set later using the API if the URL is not known at the time of configuration or is expected to change.
 - <Def id="broadcast.autostart" /> is a boolean value that determines whether the broadcast should start automatically when neko starts, works only if the URL is set.
 

--- a/webpage/docs/migration-from-v2/help.json
+++ b/webpage/docs/migration-from-v2/help.json
@@ -250,7 +250,7 @@
       "broadcast_pipeline"
     ],
     "type": "string",
-    "description": "custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced"
+    "description": "custom gst pipeline used for broadcasting, strings {hostname} {url} {device} {display} will be replaced"
   },
   {
     "key": [

--- a/webpage/docs/migration-from-v2/help.txt
+++ b/webpage/docs/migration-from-v2/help.txt
@@ -37,7 +37,7 @@
       --audio string                                  audio codec parameters to use for streaming
       --audio_bitrate int                             audio bitrate in kbit/s
 
-      --broadcast_pipeline string                     custom gst pipeline used for broadcasting, strings {url} {device} {display} will be replaced
+      --broadcast_pipeline string                     custom gst pipeline used for broadcasting, strings {hostname} {url} {device} {display} will be replaced
       --broadcast_url string                          a default default URL for broadcast streams, can be disabled/changed later by admins in the GUI
       --broadcast_autostart                           automatically start broadcasting when neko starts and broadcast_url is set
 


### PR DESCRIPTION
Allows us to have `{hostname}` in broadcast pipeline variables. In neko rooms, hostname contains the room name.