### PR TITLE
feat: support for entering text indirectly

### DIFF
--- a/client/src/utils/guacamole-keyboard.js
+++ b/client/src/utils/guacamole-keyboard.js
@@ -1365,7 +1365,60 @@ Guacamole.Keyboard = function Keyboard(element) {
 
         }, true);
 
-        // NEKO: Do not automatically type text entered into the wrapped field
+        /**
+         * Handles the given "input" event, typing the data within the input text.
+         * If the event is complete (text is provided), handling of "compositionend"
+         * events is suspended, as such events may conflict with input events.
+         *
+         * @private
+         * @param {!InputEvent} e
+         *     The "input" event to handle.
+         */
+        var handleInput = function handleInput(e) {
+
+            // Only intercept if handler set
+            if (!guac_keyboard.onkeydown && !guac_keyboard.onkeyup) return;
+
+            // Ignore events which have already been handled
+            if (!markEvent(e)) return;
+
+            // Type all content written
+            if (e.data && !e.isComposing) {
+                element.removeEventListener("compositionend", handleComposition, false);
+                guac_keyboard.type(e.data);
+            }
+
+        };
+
+        /**
+         * Handles the given "compositionend" event, typing the data within the
+         * composed text. If the event is complete (composed text is provided),
+         * handling of "input" events is suspended, as such events may conflict
+         * with composition events.
+         *
+         * @private
+         * @param {!CompositionEvent} e
+         *     The "compositionend" event to handle.
+         */
+        var handleComposition = function handleComposition(e) {
+
+            // Only intercept if handler set
+            if (!guac_keyboard.onkeydown && !guac_keyboard.onkeyup) return;
+
+            // Ignore events which have already been handled
+            if (!markEvent(e)) return;
+
+            // Type all content written
+            if (e.data) {
+                element.removeEventListener("input", handleInput, false);
+                guac_keyboard.type(e.data);
+            }
+
+        };
+
+        // Automatically type text entered into the wrapped field
+        element.addEventListener("input", handleInput, false);
+        element.addEventListener("compositionend", handleComposition, false);
 
     };
 


### PR DESCRIPTION
This PR resolves #561

I saw in this [commit a9fd6ac](https://github.com/conwnet/neko/commit/a9fd6ac1146a7068953f44a58305b9015239c1d8) that you deleted these codes, which is the reason why indirect input (such as Chinese input methods) cannot work properly.

I am not very familiar with this project, I couldn't find the PR related to this commit. I looked at the commits before and after it, and couldn't find the reason to delete this part of the code.

If this causes some bugs, please let me know, I will find other solutions.

After restoring these codes, the Chinese input method can work well.