### PR TITLE
Fix WidevineCdm download

### DIFF
--- a/apps/chromium/Dockerfile
+++ b/apps/chromium/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=ghcr.io/m1k1o/neko/base:latest
 FROM $BASE_IMAGE
 
+COPY ./widevinecdm.sh /widevine.sh
+
 #
 # install neko chromium
 RUN set -eux; \
@@ -12,19 +14,10 @@ RUN set -eux; \
     CHROMIUM_DIR="/usr/lib/chromium"; \
     ARCH=$(dpkg --print-architecture); \
     if [ "${ARCH}" = "amd64" ]; then \
-        # https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/chromeos-lacros-arm64-squash-zstd-120.0.6098.0
-        apt-get install -y --no-install-recommends unzip; \
-        WIDEVINE_ARCH="x64"; \
-        WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | sort --version-sort | tail -n 1); \
-        wget -O /tmp/widevine.zip "https://dl.google.com/widevine-cdm/${WIDEVINE_VERSION}-linux-${WIDEVINE_ARCH}.zip"; \
-        mkdir -p "${CHROMIUM_DIR}/WidevineCdm/_platform_specific/linux_${WIDEVINE_ARCH}"; \
-        unzip -p /tmp/widevine.zip LICENSE.txt > "${CHROMIUM_DIR}/WidevineCdm/LICENSE"; \
-        unzip -p /tmp/widevine.zip manifest.json > "${CHROMIUM_DIR}/WidevineCdm/manifest.json"; \
-        unzip -p /tmp/widevine.zip libwidevinecdm.so > "${CHROMIUM_DIR}/WidevineCdm/_platform_specific/linux_${WIDEVINE_ARCH}/libwidevinecdm.so"; \
-        find "${CHROMIUM_DIR}/WidevineCdm" -type d -exec chmod 0755 '{}' \;; \
-        find "${CHROMIUM_DIR}/WidevineCdm" -type f -exec chmod 0644 '{}' \;; \
-        rm /tmp/widevine.zip; \
-        apt-get --purge autoremove -y unzip; \
+        apt-get install -y --no-install-recommends xz-utils; \
+        ./widevine.sh "${CHROMIUM_DIR}/WidevineCdm"; \
+        rm -f /widevine.sh; \
+        apt-get --purge autoremove -y xz-utils; \
     else \
         echo "Widevine is not supported on ${ARCH}"; \
     fi; \

--- a/apps/chromium/Dockerfile.nvidia
+++ b/apps/chromium/Dockerfile.nvidia
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=ghcr.io/m1k1o/neko/nvidia-base:latest
 FROM $BASE_IMAGE
 
+COPY ./widevinecdm.sh /widevine.sh
+
 #
 # install neko chromium
 RUN set -eux; \
@@ -10,22 +12,15 @@ RUN set -eux; \
     # and nvidia base is ubuntu not debian
     add-apt-repository ppa:system76/pop; \
     apt-get update; \
-    apt-get install -y --no-install-recommends unzip chromium openbox; \
+    apt-get install -y --no-install-recommends xz-utils chromium openbox; \
     #
     # install widevine module
     CHROMIUM_DIR="/usr/lib/chromium"; \
-    WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | sort --version-sort | tail -n 1); \
-    wget -O /tmp/widevine.zip "https://dl.google.com/widevine-cdm/${WIDEVINE_VERSION}-linux-x64.zip"; \
-    mkdir -p "${CHROMIUM_DIR}/WidevineCdm/_platform_specific/linux_x64"; \
-    unzip -p /tmp/widevine.zip LICENSE.txt > "${CHROMIUM_DIR}/WidevineCdm/LICENSE"; \
-    unzip -p /tmp/widevine.zip manifest.json > "${CHROMIUM_DIR}/WidevineCdm/manifest.json"; \
-    unzip -p /tmp/widevine.zip libwidevinecdm.so > "${CHROMIUM_DIR}/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so"; \
-    find "${CHROMIUM_DIR}/WidevineCdm" -type d -exec chmod 0755 '{}' \;; \
-    find "${CHROMIUM_DIR}/WidevineCdm" -type f -exec chmod 0644 '{}' \;; \
-    rm /tmp/widevine.zip; \
+    ./widevine.sh "${CHROMIUM_DIR}/WidevineCdm"; \
+    rm -f /widevine.sh; \
     #
     # clean up
-    apt-get --purge autoremove -y unzip; \
+    apt-get --purge autoremove -y xz-utils; \
     apt-get clean -y; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 

--- a/apps/chromium/widevinecdm.sh
+++ b/apps/chromium/widevinecdm.sh
@@ -31,9 +31,9 @@ curl -L -o widevinecdm.crx "$URL"
 
 # Install go-crx3
 echo "Fetching latest go-crx3 version..."
-VERSION=$(curl -s https://api.github.com/repos/mmadfox/go-crx3/releases/latest | grep 'tag_name' | cut -d '"' -f4)
+VERSION=$(curl -s https://api.github.com/repos/m1k1o/go-crx3/releases/latest | grep 'tag_name' | cut -d '"' -f4)
 ARTIFACT="go-crx3_${VERSION#v}_linux_amd64.tar.gz"
-URL="https://github.com/mmadfox/go-crx3/releases/download/${VERSION}/${ARTIFACT}"
+URL="https://github.com/m1k1o/go-crx3/releases/download/${VERSION}/${ARTIFACT}"
 echo "Downloading $URL"
 curl -L -o "$ARTIFACT" "$URL"
 tar -xzf "$ARTIFACT"

--- a/apps/chromium/widevinecdm.sh
+++ b/apps/chromium/widevinecdm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+TARGET_DIR="$(realpath "$1")"
+if [ -z "$TARGET_DIR" ]; then
+    echo "Usage: $0 /path/to/install/WidevineCdm"
+    exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+
+function cleanup {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Fetch manifest and extract URL
+URL=$(python3 -c "
+import json, urllib.request
+data = json.load(urllib.request.urlopen('https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/content/gmp-sources/widevinecdm.json'))
+for v in data['vendors'].values():
+    for k, p in v['platforms'].items():
+        if 'Linux_x86_64-gcc3' in k:
+            print(p['fileUrl'])
+            break
+")
+
+# Download CRX
+curl -L -o widevinecdm.crx "$URL"
+
+# Install go-crx3
+echo "Fetching latest go-crx3 version..."
+VERSION=$(curl -s https://api.github.com/repos/mmadfox/go-crx3/releases/latest | grep 'tag_name' | cut -d '"' -f4)
+ARTIFACT="go-crx3_${VERSION#v}_linux_amd64.tar.gz"
+URL="https://github.com/mmadfox/go-crx3/releases/download/${VERSION}/${ARTIFACT}"
+echo "Downloading $URL"
+curl -L -o "$ARTIFACT" "$URL"
+tar -xzf "$ARTIFACT"
+
+# Unpack with go-crx3
+./go-crx3 unpack widevinecdm.crx
+mv widevinecdm "$TARGET_DIR"

--- a/apps/chromium/widevinecdm.sh
+++ b/apps/chromium/widevinecdm.sh
@@ -40,4 +40,5 @@ tar -xzf "$ARTIFACT"
 
 # Unpack with go-crx3
 ./go-crx3 unpack widevinecdm.crx
-mv widevinecdm "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -ar widevinecdm/* "$TARGET_DIR"

--- a/apps/ungoogled-chromium/Dockerfile
+++ b/apps/ungoogled-chromium/Dockerfile
@@ -3,6 +3,8 @@ FROM $BASE_IMAGE
 
 ARG API_URL="https://api.github.com/repos/macchrome/linchrome/releases/latest"
 
+COPY ./widevinecdm.sh /widevine.sh
+
 #
 # install custom chromium build from woolyss with support for hevc/x265
 SHELL ["/bin/bash", "-c"]
@@ -21,11 +23,9 @@ RUN set -eux; apt-get update; \
     chmod 4755 /usr/lib/chromium/chrome-sandbox; \
     #
     # install widevine module
-    WIDEVINE_VERSION=$(wget --quiet -O - https://dl.google.com/widevine-cdm/versions.txt | sort --version-sort | tail -n 1); \
-    wget -O /tmp/widevine.zip "https://dl.google.com/widevine-cdm/${WIDEVINE_VERSION}-linux-x64.zip"; \
-    unzip -p /tmp/widevine.zip libwidevinecdm.so > /usr/lib/chromium/libwidevinecdm.so; \
-    chmod 644 /usr/lib/chromium/libwidevinecdm.so; \
-    rm /tmp/widevine.zip; \
+    CHROMIUM_DIR="/usr/lib/chromium"; \
+    ./widevine.sh "${CHROMIUM_DIR}/WidevineCdm"; \
+    rm -f /widevine.sh; \
     #
     # install latest version of uBlock Origin and SponsorBlock for YouTube
     CHROMIUM_VERSION="$(wget -O - "${API_URL}" 2>/dev/null | jq -r ".tag_name" | sed -e 's/v//' -e 's/-.*//')"; \

--- a/apps/ungoogled-chromium/widevinecdm.sh
+++ b/apps/ungoogled-chromium/widevinecdm.sh
@@ -31,9 +31,9 @@ curl -L -o widevinecdm.crx "$URL"
 
 # Install go-crx3
 echo "Fetching latest go-crx3 version..."
-VERSION=$(curl -s https://api.github.com/repos/mmadfox/go-crx3/releases/latest | grep 'tag_name' | cut -d '"' -f4)
+VERSION=$(curl -s https://api.github.com/repos/m1k1o/go-crx3/releases/latest | grep 'tag_name' | cut -d '"' -f4)
 ARTIFACT="go-crx3_${VERSION#v}_linux_amd64.tar.gz"
-URL="https://github.com/mmadfox/go-crx3/releases/download/${VERSION}/${ARTIFACT}"
+URL="https://github.com/m1k1o/go-crx3/releases/download/${VERSION}/${ARTIFACT}"
 echo "Downloading $URL"
 curl -L -o "$ARTIFACT" "$URL"
 tar -xzf "$ARTIFACT"

--- a/apps/ungoogled-chromium/widevinecdm.sh
+++ b/apps/ungoogled-chromium/widevinecdm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+TARGET_DIR="$(realpath "$1")"
+if [ -z "$TARGET_DIR" ]; then
+    echo "Usage: $0 /path/to/install/WidevineCdm"
+    exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+
+function cleanup {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# Fetch manifest and extract URL
+URL=$(python3 -c "
+import json, urllib.request
+data = json.load(urllib.request.urlopen('https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/content/gmp-sources/widevinecdm.json'))
+for v in data['vendors'].values():
+    for k, p in v['platforms'].items():
+        if 'Linux_x86_64-gcc3' in k:
+            print(p['fileUrl'])
+            break
+")
+
+# Download CRX
+curl -L -o widevinecdm.crx "$URL"
+
+# Install go-crx3
+echo "Fetching latest go-crx3 version..."
+VERSION=$(curl -s https://api.github.com/repos/mmadfox/go-crx3/releases/latest | grep 'tag_name' | cut -d '"' -f4)
+ARTIFACT="go-crx3_${VERSION#v}_linux_amd64.tar.gz"
+URL="https://github.com/mmadfox/go-crx3/releases/download/${VERSION}/${ARTIFACT}"
+echo "Downloading $URL"
+curl -L -o "$ARTIFACT" "$URL"
+tar -xzf "$ARTIFACT"
+
+# Unpack with go-crx3
+./go-crx3 unpack widevinecdm.crx
+mv widevinecdm "$TARGET_DIR"

--- a/apps/ungoogled-chromium/widevinecdm.sh
+++ b/apps/ungoogled-chromium/widevinecdm.sh
@@ -40,4 +40,5 @@ tar -xzf "$ARTIFACT"
 
 # Unpack with go-crx3
 ./go-crx3 unpack widevinecdm.crx
-mv widevinecdm "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+cp -ar widevinecdm/* "$TARGET_DIR"


### PR DESCRIPTION
Latest Widevine-CDM version announced by https://dl.google.com/widevine-cdm/versions.txt that is suposed to be hosted on google https://dl.google.com/widevine-cdm/4.10.2891.0-linux-x64.zip returns 404.

As mentioned in https://github.com/NixOS/nixpkgs/issues/435671#issuecomment-3218115985, switching to the new URL and extracting content from crx3.

Awaiting this PR to be merged https://github.com/mmadfox/go-crx3/pull/18, or alternatively switching to fork https://github.com/m1k1o/go-crx3.

Unfortunately the file is duplicated, but it should not be part of the base image and to keep build context of all browsers to the browser folder, it has to be copied.