### PR TITLE
Update bookworm images

### DIFF
--- a/runtime/Dockerfile.intel.bookworm
+++ b/runtime/Dockerfile.intel.bookworm
@@ -11,11 +11,19 @@ ARG USER_GID=$USER_UID
 # install dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
+    #
+    # add non-free repo for intel drivers
+    echo deb http://deb.debian.org/debian bookworm main contrib non-free > /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free >> /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian bookworm-updates main contrib non-free >> /etc/apt/sources.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         wget ca-certificates supervisor \
         pulseaudio dbus-x11 xserver-xorg-video-dummy \
         libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx7 libx264-164 libvo-aacenc0 librtmp1 libxcvt0 \
+        #
+        # intel driver + vaapi
+        intel-media-va-driver-non-free libva2 vainfo \
         #
         # needed for profile upload preStop hook
         zip curl \
@@ -26,7 +34,7 @@ RUN set -eux; \
         # gst
         gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
         gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-        gstreamer1.0-pulseaudio; \
+        gstreamer1.0-pulseaudio gstreamer1.0-vaapi; \
     #
     # create a non-root user
     groupadd --gid $USER_GID $USERNAME; \
@@ -78,6 +86,8 @@ COPY default.pa /etc/pulse/default.pa
 COPY supervisord.conf /etc/neko/supervisord.conf
 COPY supervisord.dbus.conf /etc/neko/supervisord.dbus.conf
 COPY xorg.conf /etc/neko/xorg.conf
+COPY intel/add-render-group.sh /usr/bin/add-render-group.sh
+COPY intel/supervisord.rendergroup.conf /etc/neko/supervisord/supervisord.rendergroup.conf
 
 #
 # copy runtime folders
@@ -94,6 +104,8 @@ ENV XDG_RUNTIME_DIR=/tmp/runtime-$USERNAME
 ENV NEKO_SERVER_BIND=:8080
 ENV NEKO_PLUGINS_ENABLED=true
 ENV NEKO_PLUGINS_DIR=/etc/neko/plugins/
+ENV NEKO_HWENC=VAAPI
+ENV RENDER_GID=
 
 #
 # add healthcheck

--- a/runtime/Dockerfile.nvidia.bookworm
+++ b/runtime/Dockerfile.nvidia.bookworm
@@ -1,115 +1,70 @@
 ARG UBUNTU_RELEASE=22.04
 ARG CUDA_VERSION=12.2.0
 ARG VIRTUALGL_VERSION=3.1.3-20250409
-ARG GSTREAMER_VERSION=1.22
 
-#
-# Stage 1: Build gstreamer with nvidia plugins.
-#
-FROM ubuntu:${UBUNTU_RELEASE} AS gstreamer
-ARG GSTREAMER_VERSION
-
-#
-# install dependencies
-ENV DEBIAN_FRONTEND=noninteractive
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        # Install essentials
-        curl build-essential ca-certificates git \
-        # Install pip and ninja
-        python3-pip python-gi-dev ninja-build \
-        # Install build deps
-        autopoint autoconf automake autotools-dev libtool gettext bison flex gtk-doc-tools \
-        # Install libraries
-        librtmp-dev \
-        libvo-aacenc-dev \
-        libtool-bin \
-        libgtk2.0-dev \
-        libgl1-mesa-dev \
-        libopus-dev \
-        libpulse-dev \
-        libssl-dev \
-        libx264-dev \
-        libvpx-dev; \
-    # Install meson
-    pip3 install meson; \
-    #
-    # clean up
-    apt-get clean -y; \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#
-# build gstreamer
-RUN set -eux; \
-    git clone --depth 1 --branch $GSTREAMER_VERSION https://gitlab.freedesktop.org/gstreamer/gstreamer.git /gstreamer/src; \
-    cd /gstreamer/src; \
-    mkdir -p /usr/share/gstreamer; \
-    meson --prefix /usr/share/gstreamer \
-        -Dgpl=enabled \
-        -Dugly=enabled \
-        -Dgst-plugins-ugly:x264=enabled \
-        build; \
-    ninja -C build; \
-    meson install -C build;
-
-#
-# Stage 2: Runtime.
-#
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_RELEASE} AS runtime
-ARG UBUNTU_RELEASE
 ARG VIRTUALGL_VERSION
 
 # Make all NVIDIA GPUs visible by default
 ENV NVIDIA_VISIBLE_DEVICES=all
 # All NVIDIA driver capabilities should preferably be used, check `NVIDIA_DRIVER_CAPABILITIES` inside the container if things do not work
 ENV NVIDIA_DRIVER_CAPABILITIES=all
-
-#
-# set vgl-display to headless 3d gpu card/// correct values are egl[n] or /dev/dri/card0:if this is passed into container
+# Set vgl-display to headless 3d gpu card/// correct values are egl[n] or /dev/dri/card0:if this is passed into container
 ENV VGL_DISPLAY=egl
-
-#
-# set custom user
-ARG USERNAME=neko
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 
 #
 # install hardware accleration dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
-    dpkg --add-architecture i386; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        wget gpg ca-certificates \
         # opengl base: https://gitlab.com/nvidia/container-images/opengl/-/blob/ubuntu20.04/base/Dockerfile
-        libxau6 libxau6:i386 \
-        libxdmcp6 libxdmcp6:i386 \
-        libxcb1 libxcb1:i386 \
-        libxext6 libxext6:i386 \
-        libx11-6 libx11-6:i386 \
+        libxau6 libxdmcp6 libxcb1 libxext6 libx11-6 \
         # opengl runtime: https://gitlab.com/nvidia/container-images/opengl/-/blob/ubuntu20.04/glvnd/runtime/Dockerfile
-        libglvnd0 libglvnd0:i386 \
-        libgl1 libgl1:i386 \
-        libglx0 libglx0:i386 \
-        libegl1 libegl1:i386 \
-        libgles2 libgles2:i386 \
+        libglvnd0 libgl1 libglx0 libegl1 libgles2 \
         # hardware accleration utilities
-        libglu1 libglu1:i386 \
-        libvulkan-dev libvulkan-dev:i386 \
-        mesa-utils mesa-utils-extra \
-        mesa-va-drivers mesa-vulkan-drivers \
-        vainfo vdpauinfo; \
+        libglu1 libvulkan-dev vainfo vdpauinfo vulkan-tools \
+        mesa-utils mesa-utils-extra mesa-va-drivers mesa-vulkan-drivers; \
     #
-    # install vulkan-utils or vulkan-tools depending on ubuntu release
-    if [ "${UBUNTU_RELEASE}" = "18.04" ]; then \
-        apt-get install -y --no-install-recommends vulkan-utils; \
-    else \
-        apt-get install -y --no-install-recommends vulkan-tools; \
+    # install an up-to-date version of VirtualGL
+    if [ -n "${VIRTUALGL_VERSION}" ]; then \
+        #
+        # add VirtualGL GPG key
+        wget -q -O- https://packagecloud.io/dcommander/virtualgl/gpgkey | \
+        gpg --dearmor >/etc/apt/trusted.gpg.d/VirtualGL.gpg; \
+        #
+        # download the official VirtualGL.list file
+        wget -q -O /etc/apt/sources.list.d/VirtualGL.list \
+            https://raw.githubusercontent.com/VirtualGL/repo/main/VirtualGL.list; \
+        #
+        # install packages
+        apt-get update; \
+        apt-get install -y --no-install-recommends virtualgl=${VIRTUALGL_VERSION}; \
     fi; \
     #
     # create symlink for libnvrtc.so (needed for cudaconvert)
     find /usr/local/cuda/lib64/ -maxdepth 1 -type l -name "*libnvrtc.so.*" -exec sh -c 'ln -sf {} /usr/local/cuda/lib64/libnvrtc.so' \;; \
+    #
+    # configure EGL manually
+    mkdir -p /usr/share/glvnd/egl_vendor.d/; \
+    echo "{\n\
+        \"file_format_version\" : \"1.0.0\",\n\
+        \"ICD\": {\n\
+            \"library_path\": \"libEGL_nvidia.so.0\"\n\
+        }\n\
+    }" > /usr/share/glvnd/egl_vendor.d/10_nvidia.json; \
+    #
+    # configure Vulkan manually
+    VULKAN_API_VERSION=$(dpkg -s libvulkan1 | grep -oP 'Version: [0-9|\.]+' | grep -oP '[0-9]+(\.[0-9]+)(\.[0-9]+)'); \
+    mkdir -p /etc/vulkan/icd.d/; \
+    echo "{\n\
+        \"file_format_version\" : \"1.0.0\",\n\
+        \"ICD\": {\n\
+            \"library_path\": \"libGLX_nvidia.so.0\",\n\
+            \"api_version\" : \"${VULKAN_API_VERSION}\"\n\
+        }\n\
+    }" > /etc/vulkan/icd.d/nvidia_icd.json; \
     #
     # clean up
     apt-get clean -y; \
@@ -120,21 +75,35 @@ RUN set -eux; \
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/cuda/lib:/usr/local/cuda/lib64"
 
 #
+# entrypoint script that sets up VirtualGL and runs commands
+COPY nvidia/entrypoint.sh /bin/entrypoint.sh
+
+#
+# set custom user
+ARG USERNAME=neko
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+#
 # install dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         wget ca-certificates supervisor \
-        pulseaudio xserver-xorg-video-dummy \
+        pulseaudio dbus-x11 xserver-xorg-video-dummy \
         libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx7 libx264-163 libvo-aacenc0 librtmp1 libxcvt0 \
-        libgtk-3-bin software-properties-common cabextract aptitude vim curl \
         #
         # needed for profile upload preStop hook
         zip curl \
         #
         # file chooser handler, clipboard, drop
-        xdotool xclip libgtk-3-0; \
+        xdotool xclip libgtk-3-0 \
+        #
+        # gst
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+        gstreamer1.0-pulseaudio; \
     #
     # create a non-root user
     groupadd --gid $USER_GID $USERNAME; \
@@ -154,6 +123,7 @@ RUN set -eux; \
         /home/$USERNAME/.config/pulse  \
         /home/$USERNAME/.local/share/xorg; \
     chmod 1777 /var/log/neko; \
+    chmod 0700 /tmp/runtime-$USERNAME; \
     chown $USERNAME /var/log/neko/ /tmp/runtime-$USERNAME; \
     chown -R $USERNAME:$USERNAME /home/$USERNAME; \
     #
@@ -178,51 +148,13 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #
-# configure EGL and Vulkan manually
-RUN VULKAN_API_VERSION=$(dpkg -s libvulkan1 | grep -oP 'Version: [0-9|\.]+' | grep -oP '[0-9]+(\.[0-9]+)(\.[0-9]+)') && \
-    # Configure EGL manually
-    mkdir -p /usr/share/glvnd/egl_vendor.d/ && \
-    echo "{\n\
-    \"file_format_version\" : \"1.0.0\",\n\
-    \"ICD\": {\n\
-        \"library_path\": \"libEGL_nvidia.so.0\"\n\
-    }\n\
-}" > /usr/share/glvnd/egl_vendor.d/10_nvidia.json && \
-    # Configure Vulkan manually
-    mkdir -p /etc/vulkan/icd.d/ && \
-    echo "{\n\
-    \"file_format_version\" : \"1.0.0\",\n\
-    \"ICD\": {\n\
-        \"library_path\": \"libGLX_nvidia.so.0\",\n\
-        \"api_version\" : \"${VULKAN_API_VERSION}\"\n\
-    }\n\
-}" > /etc/vulkan/icd.d/nvidia_icd.json
-
-#
-# install an up-to-date version of VirtualGL
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends wget gpg ca-certificates; \
-    # Add VirtualGL GPG key
-    wget -q -O- https://packagecloud.io/dcommander/virtualgl/gpgkey | \
-    gpg --dearmor >/etc/apt/trusted.gpg.d/VirtualGL.gpg; \
-    # Download the official VirtualGL.list file
-    wget -q -O /etc/apt/sources.list.d/VirtualGL.list \
-        https://raw.githubusercontent.com/VirtualGL/repo/main/VirtualGL.list; \
-    # Install packages
-    apt-get update; \
-    apt-get install -y --no-install-recommends virtualgl=${VIRTUALGL_VERSION}; \
-    #
-    # clean up
-    apt-get clean -y; \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#
 # copy runtime configs
 COPY --chown=neko:neko .Xresources /home/$USERNAME/.Xresources
+COPY dbus /usr/bin/dbus
 COPY default.pa /etc/pulse/default.pa
 COPY supervisord.conf /etc/neko/supervisord.conf
+COPY supervisord.dbus.conf /etc/neko/supervisord.dbus.conf
 COPY xorg.conf /etc/neko/xorg.conf
-COPY nvidia/entrypoint.sh /bin/entrypoint.sh
 
 #
 # copy runtime folders
@@ -239,16 +171,6 @@ ENV XDG_RUNTIME_DIR=/tmp/runtime-$USERNAME
 ENV NEKO_SERVER_BIND=:8080
 ENV NEKO_PLUGINS_ENABLED=true
 ENV NEKO_PLUGINS_DIR=/etc/neko/plugins/
-
-#
-# set gstreamer envs
-ENV PATH="/usr/share/gstreamer/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/share/gstreamer/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-ENV PKG_CONFIG_PATH="/usr/share/gstreamer/lib/x86_64-linux-gnu/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
-
-#
-# copy artifacts from previous stages
-COPY --from=gstreamer /usr/share/gstreamer /usr/share/gstreamer
 
 #
 # add healthcheck


### PR DESCRIPTION
- we don't need to build gstreamer anymore because there is already a quite recent version that supports cuda.
- removed not needed apt packages of i386 arch.

This is a part of #531 where we update thte images in own separated maintained Dockerfiles first.