### PR TITLE
Add AMD GPU hardware acceleration support

### DIFF
--- a/.github/workflows/ghcr_amd.yml
+++ b/.github/workflows/ghcr_amd.yml
@@ -1,0 +1,45 @@
+name: Build and Push to GHCR for AMD
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-base:
+    name: Base Image
+    uses: ./.github/workflows/image_base.yml
+    with:
+      flavor: amd
+      platforms: linux/amd64
+      dockerfile: Dockerfile.amd
+    secrets: inherit
+
+  build-app:
+    name: App Image
+    uses: ./.github/workflows/image_app.yml
+    needs: build-base
+    strategy:
+      # Will build all images even if some fail.
+      fail-fast: false
+      matrix:
+        include:
+          - name: firefox
+          - name: chromium
+          - name: google-chrome
+          - name: ungoogled-chromium
+          - name: microsoft-edge
+          - name: brave
+          - name: vivaldi
+          - name: opera
+          - name: tor-browser
+          - name: remmina
+          - name: vlc
+          - name: xfce
+          - name: kde
+    with:
+      name: ${{ matrix.name }}
+      flavor: amd
+      platforms: ${{ matrix.platforms }}
+      dockerfile: ${{ matrix.dockerfile }}
+    secrets: inherit

--- a/runtime/Dockerfile.amd
+++ b/runtime/Dockerfile.amd
@@ -1,0 +1,124 @@
+ARG BASE_IMAGE=debian:bullseye-slim
+FROM $BASE_IMAGE AS runtime
+
+#
+# set custom user
+ARG USERNAME=neko
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+#
+# install dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+RUN set -eux; \
+    #
+    # add non-free repo for mesa drivers
+    echo deb http://deb.debian.org/debian bullseye main contrib non-free > /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free >> /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian bullseye-updates main contrib non-free >> /etc/apt/sources.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        wget ca-certificates supervisor \
+        pulseaudio dbus-x11 xserver-xorg-video-dummy \
+        libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx6 \
+        #
+        # amd driver + vaapi (mesa radeonsi)
+        mesa-va-drivers libva2 vainfo \
+        #
+        # needed for profile upload preStop hook
+        zip curl \
+        #
+        # file chooser handler, clipboard, drop
+        xdotool xclip libgtk-3-0 \
+        #
+        # gst
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+        gstreamer1.0-pulseaudio gstreamer1.0-vaapi; \
+    #
+    # install libxcvt0 (not available in debian:bullseye)
+    ARCH=$(dpkg --print-architecture); \
+    wget http://ftp.de.debian.org/debian/pool/main/libx/libxcvt/libxcvt0_0.1.2-1_${ARCH}.deb; \
+    apt-get install --no-install-recommends ./libxcvt0_0.1.2-1_${ARCH}.deb; \
+    rm ./libxcvt0_0.1.2-1_${ARCH}.deb; \
+    #
+    # create a non-root user
+    groupadd --gid $USER_GID $USERNAME; \
+    useradd --uid $USER_UID --gid $USERNAME --shell /bin/bash --create-home $USERNAME; \
+    adduser $USERNAME audio; \
+    adduser $USERNAME video; \
+    adduser $USERNAME pulse; \
+    #
+    # workaround for an X11 problem: http://blog.tigerteufel.de/?p=476
+    mkdir /tmp/.X11-unix; \
+    chmod 1777 /tmp/.X11-unix; \
+    chown $USERNAME /tmp/.X11-unix/; \
+    #
+    # make directories for neko
+    mkdir -p /etc/neko /var/www /var/log/neko \
+        /tmp/runtime-$USERNAME \
+        /home/$USERNAME/.config/pulse  \
+        /home/$USERNAME/.local/share/xorg; \
+    chmod 1777 /var/log/neko; \
+    chown $USERNAME /var/log/neko/ /tmp/runtime-$USERNAME; \
+    chown -R $USERNAME:$USERNAME /home/$USERNAME; \
+    #
+    # install fonts
+    apt-get install -y --no-install-recommends \
+        # Emojis
+        fonts-noto-color-emoji \
+        # Chinese fonts
+        fonts-arphic-ukai fonts-arphic-uming \
+        fonts-wqy-zenhei xfonts-intl-chinese xfonts-wqy \
+        # Japanese fonts
+        fonts-ipafont-mincho fonts-ipafont-gothic \
+        fonts-takao-mincho \
+        # Korean fonts
+        fonts-unfonts-core \
+        fonts-wqy-microhei \
+        # Indian fonts
+        fonts-indic; \
+    #
+    # clean up
+    apt-get clean -y; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+#
+# copy runtime configs
+COPY --chown=neko:neko .Xresources /home/$USERNAME/.Xresources
+COPY dbus /usr/bin/dbus
+COPY default.pa /etc/pulse/default.pa
+COPY supervisord.conf /etc/neko/supervisord.conf
+COPY supervisord.dbus.conf /etc/neko/supervisord.dbus.conf
+COPY xorg.conf /etc/neko/xorg.conf
+COPY amd/add-render-group.sh /usr/bin/add-render-group.sh
+COPY amd/supervisord.rendergroup.conf /etc/neko/supervisord/supervisord.rendergroup.conf
+
+#
+# copy runtime folders
+COPY --chown=neko:neko icon-theme /home/$USERNAME/.icons/default
+COPY fontconfig/* /etc/fonts/conf.d/
+COPY fonts /usr/local/share/fonts
+
+#
+# set default envs
+ENV USER=$USERNAME
+ENV DISPLAY=:99.0
+ENV PULSE_SERVER=unix:/tmp/pulseaudio.socket
+ENV XDG_RUNTIME_DIR=/tmp/runtime-$USERNAME
+ENV NEKO_SERVER_BIND=:8080
+ENV NEKO_PLUGINS_ENABLED=true
+ENV NEKO_PLUGINS_DIR=/etc/neko/plugins/
+ENV NEKO_HWENC=VAAPI
+ENV NEKO_VIDEO_CODEC=h264
+ENV RENDER_GID=
+
+#
+# add healthcheck
+HEALTHCHECK --interval=10s --timeout=5s --retries=8 \
+    CMD wget -O - http://localhost:${NEKO_SERVER_BIND#*:}/health || \
+        wget --no-check-certificate -O - https://localhost:${NEKO_SERVER_BIND#*:}/health || \
+        exit 1
+#
+# run neko
+CMD ["/usr/bin/supervisord", "-c", "/etc/neko/supervisord.conf"]

--- a/runtime/Dockerfile.amd.bookworm
+++ b/runtime/Dockerfile.amd.bookworm
@@ -1,0 +1,120 @@
+ARG BASE_IMAGE=debian:bookworm-slim
+FROM $BASE_IMAGE AS runtime
+
+#
+# set custom user
+ARG USERNAME=neko
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+#
+# install dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+RUN set -eux; \
+    #
+    # add non-free repo for mesa drivers
+    echo deb http://deb.debian.org/debian bookworm main contrib non-free > /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free >> /etc/apt/sources.list; \
+    echo deb http://deb.debian.org/debian bookworm-updates main contrib non-free >> /etc/apt/sources.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        wget ca-certificates supervisor \
+        pulseaudio dbus-x11 xserver-xorg-video-dummy \
+        libcairo2 libxcb1 libxrandr2 libxv1 libopus0 libvpx7 libx264-164 libvo-aacenc0 librtmp1 libxcvt0 \
+        #
+        # amd driver + vaapi (mesa radeonsi)
+        mesa-va-drivers libva2 vainfo \
+        #
+        # needed for profile upload preStop hook
+        zip curl \
+        #
+        # file chooser handler, clipboard, drop
+        xdotool xclip libgtk-3-0 \
+        #
+        # gst
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+        gstreamer1.0-pulseaudio gstreamer1.0-vaapi; \
+    #
+    # create a non-root user
+    groupadd --gid $USER_GID $USERNAME; \
+    useradd --uid $USER_UID --gid $USERNAME --shell /bin/bash --create-home $USERNAME; \
+    adduser $USERNAME audio; \
+    adduser $USERNAME video; \
+    adduser $USERNAME pulse; \
+    #
+    # workaround for an X11 problem: http://blog.tigerteufel.de/?p=476
+    mkdir /tmp/.X11-unix; \
+    chmod 1777 /tmp/.X11-unix; \
+    chown $USERNAME /tmp/.X11-unix/; \
+    #
+    # make directories for neko
+    mkdir -p /etc/neko /var/www /var/log/neko \
+        /tmp/runtime-$USERNAME \
+        /home/$USERNAME/.config/pulse  \
+        /home/$USERNAME/.local/share/xorg; \
+    chmod 1777 /var/log/neko; \
+    chmod 0700 /tmp/runtime-$USERNAME; \
+    chown $USERNAME /var/log/neko/ /tmp/runtime-$USERNAME; \
+    chown -R $USERNAME:$USERNAME /home/$USERNAME; \
+    #
+    # install fonts
+    apt-get install -y --no-install-recommends \
+        # Emojis
+        fonts-noto-color-emoji \
+        # Chinese fonts
+        fonts-arphic-ukai fonts-arphic-uming \
+        fonts-wqy-zenhei xfonts-intl-chinese xfonts-wqy \
+        # Japanese fonts
+        fonts-ipafont-mincho fonts-ipafont-gothic \
+        fonts-takao-mincho \
+        # Korean fonts
+        fonts-unfonts-core \
+        fonts-wqy-microhei \
+        # Indian fonts
+        fonts-indic; \
+    #
+    # clean up
+    apt-get clean -y; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+#
+# copy runtime configs
+COPY --chown=neko:neko .Xresources /home/$USERNAME/.Xresources
+COPY dbus /usr/bin/dbus
+COPY default.pa /etc/pulse/default.pa
+COPY supervisord.conf /etc/neko/supervisord.conf
+COPY supervisord.dbus.conf /etc/neko/supervisord.dbus.conf
+COPY xorg.conf /etc/neko/xorg.conf
+COPY amd/add-render-group.sh /usr/bin/add-render-group.sh
+COPY amd/supervisord.rendergroup.conf /etc/neko/supervisord/supervisord.rendergroup.conf
+
+#
+# copy runtime folders
+COPY --chown=neko:neko icon-theme /home/$USERNAME/.icons/default
+COPY fontconfig/* /etc/fonts/conf.d/
+COPY fonts /usr/local/share/fonts
+
+#
+# set default envs
+ENV USER=$USERNAME
+ENV DISPLAY=:99.0
+ENV PULSE_SERVER=unix:/tmp/pulseaudio.socket
+ENV XDG_RUNTIME_DIR=/tmp/runtime-$USERNAME
+ENV NEKO_SERVER_BIND=:8080
+ENV NEKO_PLUGINS_ENABLED=true
+ENV NEKO_PLUGINS_DIR=/etc/neko/plugins/
+ENV NEKO_HWENC=VAAPI
+ENV NEKO_VIDEO_CODEC=h264
+ENV RENDER_GID=
+
+#
+# add healthcheck
+HEALTHCHECK --interval=10s --timeout=5s --retries=8 \
+    CMD wget -O - http://localhost:${NEKO_SERVER_BIND#*:}/health || \
+        wget --no-check-certificate -O - https://localhost:${NEKO_SERVER_BIND#*:}/health || \
+        exit 1
+
+#
+# run neko
+CMD ["/usr/bin/supervisord", "-c", "/etc/neko/supervisord.conf"]

--- a/runtime/amd/add-render-group.sh
+++ b/runtime/amd/add-render-group.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# if no hwenc required, noop
+[[ -z "$NEKO_HWENC" ]] && exit 0
+
+if [[ -z "$RENDER_GID" ]]; then
+  RENDER_GID=$(stat -c "%g" /dev/dri/render* | tail -n 1)
+  # is /dev/dri passed to the container?
+  [[ -z "$RENDER_GID" ]] && exit 1
+fi
+
+# note that this could conceivably be a security risk...
+cnt_group=$(getent group "$RENDER_GID" | cut -d: -f1)
+if [[ -z "$cnt_group" ]]; then
+  groupadd -g "$RENDER_GID" nekorender
+  cnt_group=nekorender
+fi
+usermod -a -G "$cnt_group" "$USER"

--- a/runtime/amd/supervisord.rendergroup.conf
+++ b/runtime/amd/supervisord.rendergroup.conf
@@ -1,0 +1,12 @@
+[program:rendergroup-init]
+environment=RENDER_GID="%(ENV_RENDER_GID)s",USER="%(ENV_USER)s"
+command=/usr/bin/add-render-group.sh
+startsecs=0
+startretries=0
+autorestart=false
+priority=10
+user=root
+stdout_logfile=/var/log/neko/rendergroup.log
+stdout_logfile_maxbytes=1MB
+stdout_logfile_backups=10
+redirect_stderr=true

--- a/utils/xorg-deps/Dockerfile
+++ b/utils/xorg-deps/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:bullseye-slim
+ARG BASE_IMAGE=debian:bookworm-slim
 FROM $BASE_IMAGE AS xorg-deps
 
 WORKDIR /xorg


### PR DESCRIPTION
## Summary
Add AMD GPU hardware acceleration support using Mesa's radeonsi VA-API driver for hardware video encoding. Tested with Ryzen 9 9950X integrated graphics.

## Changes
- `runtime/Dockerfile.amd` - Bullseye-based runtime for Polaris/Vega/RDNA1/RDNA2 GPUs
- `runtime/Dockerfile.amd.bookworm` - Bookworm-based runtime for Zen 4 APUs and RDNA3 GPUs
- `runtime/amd/add-render-group.sh` - Script to add neko user to render group for GPU access
- `runtime/amd/supervisord.rendergroup.conf` - Supervisor config for render group setup
- `.github/workflows/ghcr_amd.yml` - CI workflow for AMD image builds
- `utils/xorg-deps/Dockerfile` - Updated to bookworm for xorg ABI 25 compatibility

## Test Plan
- [x] Verified AMD GPU detection (Ryzen 9 9950X integrated Radeon Graphics - gfx1036)
- [x] Built bookworm variant with Mesa 22.3 (required for Zen 4 support)
- [x] Verified xorg-deps ABI compatibility (rebuilt with bookworm base)
- [x] Tested neko container with Firefox browser
- [x] Confirmed VAAPI hardware encoding with `vaapih264enc` GStreamer pipeline
- [x] Verified WebRTC connection and video streaming works

## Usage
**Important: AMD GPUs only support H264/HEVC hardware encoding, not VP8/VP9.**

```bash
docker run -d \
  --device /dev/dri:/dev/dri \
  -e NEKO_VIDEO_CODEC=h264 \
  -e NEKO_HWENC=vaapi \
  -e LIBVA_DRIVER_NAME=radeonsi \
  -e LIBVA_DEVICE=/dev/dri/renderD128 \
  ghcr.io/m1k1o/neko/firefox:amd
```

Adjust `LIBVA_DEVICE` to your AMD GPU render node (check with `ls /dev/dri/render*`).