### PR TITLE
fix(server): include path prefix in legacy API calls (#615)

### DIFF
--- a/server/internal/http/legacy/session.go
+++ b/server/internal/http/legacy/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strings"
 	"sync"
 
@@ -35,6 +36,7 @@ type session struct {
 
 	logger     zerolog.Logger
 	serverAddr string
+	pathPrefix string
 
 	id, ip  string
 	token   string
@@ -63,6 +65,7 @@ func (h *LegacyHandler) newSession(r *http.Request) *session {
 		h:          h,
 		logger:     h.logger,
 		serverAddr: h.serverAddr,
+		pathPrefix: h.pathPrefix,
 		client: &http.Client{
 			Transport: transport,
 		},
@@ -70,8 +73,8 @@ func (h *LegacyHandler) newSession(r *http.Request) *session {
 	}
 }
 
-func (s *session) req(method, path string, headers http.Header, request io.Reader) (io.ReadCloser, http.Header, error) {
-	req, err := http.NewRequest(method, "http://"+s.serverAddr+path, request)
+func (s *session) req(method, reqPath string, headers http.Header, request io.Reader) (io.ReadCloser, http.Header, error) {
+	req, err := http.NewRequest(method, "http://"+s.serverAddr+path.Join(s.pathPrefix, reqPath), request)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/internal/http/manager.go
+++ b/server/internal/http/manager.go
@@ -134,7 +134,7 @@ func (manager *HttpManagerCtx) Start() {
 			}()
 			manager.logger.Info().Msgf("legacy proxy listening on %s", listener.Addr().String())
 
-			legacy.New(listener.Addr().String()).Route(manager.router)
+			legacy.New(listener.Addr().String(), manager.config.PathPrefix).Route(manager.router)
 		}
 	} else {
 		go func() {
@@ -146,7 +146,7 @@ func (manager *HttpManagerCtx) Start() {
 
 		// start legacy proxy if enabled
 		if viper.GetBool("legacy") {
-			legacy.New(manager.http.Addr).Route(manager.router)
+			legacy.New(manager.http.Addr, manager.config.PathPrefix).Route(manager.router)
 		}
 	}
 }


### PR DESCRIPTION
Resolves #615 by ensuring legacy requests respect the configured path prefix to prevent 404 errors