### PR TITLE
Add support for H265 encoded streams

### DIFF
--- a/server/internal/config/capture_pipeline.go
+++ b/server/internal/config/capture_pipeline.go
@@ -168,7 +168,7 @@ func NewVideoPipeline(rtpCodec codec.RTPCodec, display string, pipelineSrc strin
 				nvencElem = "nvautogpuh264enc"
 			}
 
-			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! %s name=encoder preset=2 gop-size=25 spatial-aq=true temporal-aq=true bitrate=%d vbv-buffer-size=%d rc-mode=6 ! h264parse config-interval=-1 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, nvencElem, bitrate, vbvbuf)
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! %s name=encoder preset=2 gop-size=60 spatial-aq=true temporal-aq=true bitrate=%d vbv-buffer-size=%d rc-mode=6 ! h264parse config-interval=-1 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, nvencElem, bitrate, vbvbuf)
 		default:
 			// https://gstreamer.freedesktop.org/documentation/openh264/openh264enc.html?gi-language=c#openh264enc
 			// gstreamer1.0-plugins-bad
@@ -204,13 +204,13 @@ func NewVideoPipeline(rtpCodec codec.RTPCodec, display string, pipelineSrc strin
 				return "", err
 			}
 
-			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! vah265enc rate-control=cbr bitrate=%d key-int-max=60 target-usage=7 ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate)
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! vah265enc rate-control=cbr bitrate=%d key-int-max=60 target-usage=7 ! h265parse config-interval=-1 ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate)
 		case HwEncNVENC:
 			if err := gst.CheckPlugins([]string{"nvcodec"}); err != nil {
 				return "", err
 			}
 
-			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh265enc name=encoder rc-mode=cbr preset=p2 tune=low-latency gop-size=25 bitrate=%d vbv-buffer-size=%d ! h265parse config-interval=-1 ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate, vbvbuf)
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh265enc name=encoder rc-mode=cbr preset=p2 tune=low-latency gop-size=60 bitrate=%d vbv-buffer-size=%d ! h265parse config-interval=-1 ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate, vbvbuf)
 		default:
 			// https://gstreamer.freedesktop.org/documentation/x265/index.html?gi-language=c
 			// gstreamer1.0-plugins-bad

--- a/server/internal/config/capture_pipeline.go
+++ b/server/internal/config/capture_pipeline.go
@@ -187,6 +187,39 @@ func NewVideoPipeline(rtpCodec codec.RTPCodec, display string, pipelineSrc strin
 
 			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! x264enc threads=4 bitrate=%d key-int-max=60 vbv-buf-capacity=%d byte-stream=true tune=zerolatency speed-preset=veryfast ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate, vbvbuf)
 		}
+
+	case codec.H265().Name:
+		if err := gst.CheckPlugins([]string{"ximagesrc"}); err != nil {
+			return "", err
+		}
+
+		vbvbuf := uint(1000)
+		if bitrate > 1000 {
+			vbvbuf = bitrate
+		}
+
+		switch hwenc {
+		case HwEncVAAPI:
+			if err := gst.CheckPlugins([]string{"va"}); err != nil {
+				return "", err
+			}
+
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! vah265enc rate-control=cbr bitrate=%d key-int-max=60 target-usage=7 ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate)
+		case HwEncNVENC:
+			if err := gst.CheckPlugins([]string{"nvcodec"}); err != nil {
+				return "", err
+			}
+
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! nvh265enc name=encoder rc-mode=cbr preset=p2 tune=low-latency gop-size=25 bitrate=%d vbv-buffer-size=%d ! h265parse config-interval=-1 ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate, vbvbuf)
+		default:
+			// https://gstreamer.freedesktop.org/documentation/x265/index.html?gi-language=c
+			// gstreamer1.0-plugins-bad
+			if err := gst.CheckPlugins([]string{"x265"}); err != nil {
+				return "", err
+			}
+
+			pipelineStr = fmt.Sprintf(videoSrc+"x265enc bitrate=%d key-int-max=60 tune=zerolatency speed-preset=veryfast option-string=\"vbv-maxrate=%d:vbv-bufsize=%d\" ! video/x-h265,stream-format=byte-stream,profile=main"+pipelineStr, display, fps, bitrate, bitrate, vbvbuf)
+		}
 	default:
 		return "", fmt.Errorf("unknown codec %s", rtpCodec.Name)
 	}

--- a/server/internal/config/capture_pipeline.go
+++ b/server/internal/config/capture_pipeline.go
@@ -152,11 +152,11 @@ func NewVideoPipeline(rtpCodec codec.RTPCodec, display string, pipelineSrc strin
 
 		switch hwenc {
 		case HwEncVAAPI:
-			if err := gst.CheckPlugins([]string{"vaapi"}); err != nil {
+			if err := gst.CheckPlugins([]string{"va"}); err != nil {
 				return "", err
 			}
 
-			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! vaapih264enc rate-control=vbr bitrate=%d keyframe-period=180 quality-level=7 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate)
+			pipelineStr = fmt.Sprintf(videoSrc+"video/x-raw,format=NV12 ! vah264enc rate-control=cbr bitrate=%d key-int-max=60 target-usage=7 ! h264parse config-interval=-1 ! video/x-h264,stream-format=byte-stream,profile=constrained-baseline"+pipelineStr, display, fps, bitrate)
 		case HwEncNVENC:
 			if err := gst.CheckPlugins([]string{"nvcodec"}); err != nil {
 				return "", err

--- a/server/pkg/types/codec/codecs.go
+++ b/server/pkg/types/codec/codecs.go
@@ -35,6 +35,8 @@ func ParseStr(codecName string) (codec RTPCodec, ok bool) {
 		codec = AV1()
 	case H264().Name:
 		codec = H264()
+	case H265().Name:
+		codec = H265()
 	case Opus().Name:
 		codec = Opus()
 	case G722().Name:
@@ -133,6 +135,24 @@ func H264() RTPCodec {
 		// https://gstreamer.freedesktop.org/documentation/openh264/openh264enc.html
 		// gstreamer1.0-plugins-bad
 		//Pipeline: "openh264enc multi-thread=4 complexity=high bitrate=3072000 max-bitrate=4096000 ! video/x-h264,stream-format=byte-stream",
+	}
+}
+
+func H265() RTPCodec {
+	return RTPCodec{
+		Name:        "h265",
+		PayloadType: 116,
+		Type:        webrtc.RTPCodecTypeVideo,
+		Capability: webrtc.RTPCodecCapability{
+			MimeType:     webrtc.MimeTypeH265,
+			ClockRate:    90000,
+			Channels:     0,
+			SDPFmtpLine:  "profile-id=1;level-id=93;tx-mode=SRST",
+			RTCPFeedback: RTCPFeedback,
+		},
+		// https://gstreamer.freedesktop.org/documentation/x265/index.html
+		// gstreamer1.0-plugins-bad
+		Pipeline: "x265enc bitrate=4096 key-int-max=60 tune=zerolatency speed-preset=veryfast option-string=\"vbv-maxrate=4096:vbv-bufsize=4096\" ! video/x-h265,stream-format=byte-stream,profile=main",
 	}
 }
 

--- a/webpage/docs/configuration/capture.md
+++ b/webpage/docs/configuration/capture.md
@@ -38,7 +38,7 @@ The Gstreamer pipeline is started when the first client requests the video strea
 ]} comments={false} />
 
 - <Def id="video.display" /> is the name of the [X display](https://www.x.org/wiki/) that you want to capture. If not specified, the environment variable `DISPLAY` will be used.
-- <Def id="video.codec" /> available codecs are `vp8`, `vp9`, `av1`, `h264`. [Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) are dependent on the WebRTC implementation used by the client, `vp8` and `h264` are supported by all WebRTC implementations.
+- <Def id="video.codec" /> available codecs are `vp8`, `vp9`, `av1`, `h264`, `h265`. [Supported video codecs](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs#supported_video_codecs) are dependent on the WebRTC implementation used by the client, `vp8` and `h264` are supported by all WebRTC implementations.
 - <Def id="video.ids" /> is a list of pipeline ids that are defined in the <Opt id="video.pipelines" /> section. The first pipeline in the list will be the default pipeline.
 - <Def id="video.pipeline" /> is a shorthand for defining [Gstreamer pipeline description](#video.gst_pipeline) for a single pipeline. This is option is ignored if <Opt id="video.pipelines" /> is defined.
 - <Def id="video.pipelines" /> is a dictionary of pipeline configurations. Each pipeline configuration is defined by a unique pipeline id. They can be defined in two ways: either by building the pipeline dynamically using [Expression-Driven Configuration](#video.expression) or by defining the pipeline using a [Gstreamer Pipeline Description](#video.gst_pipeline).
@@ -322,8 +322,8 @@ Overview of available encoders for each codec is shown in the table below. The e
 | VP8   | [vp8enc](https://gstreamer.freedesktop.org/documentation/vpx/vp8enc.html?gi-language=c) | [vaapivp8enc](https://github.com/GStreamer/gstreamer-vaapi/blob/master/gst/vaapi/gstvaapiencode_vp8.c) | ? |
 | VP9   | [vp9enc](https://gstreamer.freedesktop.org/documentation/vpx/vp9enc.html?gi-language=c) | [vaapivp9enc](https://github.com/GStreamer/gstreamer-vaapi/blob/master/gst/vaapi/gstvaapiencode_vp9.c) | ? |
 | AV1   | [av1enc](https://gstreamer.freedesktop.org/documentation/aom/av1enc.html?gi-language=c) | ? | [nvav1enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvav1enc.html?gi-language=c) |
-| H264  | [x264enc](https://gstreamer.freedesktop.org/documentation/x264/index.html?gi-language=c) | [vaapih264enc](https://gstreamer.freedesktop.org/documentation/vaapi/vaapih264enc.html?gi-language=c) | [nvautogpuh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvautogpuh264enc.html?gi-language=c) / [nvh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh264enc.html?gi-language=c) |
-| H265  | [x265enc](https://gstreamer.freedesktop.org/documentation/x265/index.html?gi-language=c) | [vaapih265enc](https://gstreamer.freedesktop.org/documentation/vaapi/vaapih265enc.html?gi-language=c) | [nvh265enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh265enc.html?gi-language=c) |
+| H264  | [x264enc](https://gstreamer.freedesktop.org/documentation/x264/index.html?gi-language=c) | [vaapih264enc](https://gstreamer.freedesktop.org/documentation/va/vah264enc.html?gi-language=c) | [nvautogpuh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvautogpuh264enc.html?gi-language=c) / [nvh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh264enc.html?gi-language=c) |
+| H265  | [x265enc](https://gstreamer.freedesktop.org/documentation/x265/index.html?gi-language=c) | [vaapih265enc](https://gstreamer.freedesktop.org/documentation/va/vah265enc.html?gi-language=c) | [nvh265enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh265enc.html?gi-language=c) |
 
 
 ## WebRTC Audio {#audio}

--- a/webpage/docs/configuration/capture.md
+++ b/webpage/docs/configuration/capture.md
@@ -322,8 +322,8 @@ Overview of available encoders for each codec is shown in the table below. The e
 | VP8   | [vp8enc](https://gstreamer.freedesktop.org/documentation/vpx/vp8enc.html?gi-language=c) | [vaapivp8enc](https://github.com/GStreamer/gstreamer-vaapi/blob/master/gst/vaapi/gstvaapiencode_vp8.c) | ? |
 | VP9   | [vp9enc](https://gstreamer.freedesktop.org/documentation/vpx/vp9enc.html?gi-language=c) | [vaapivp9enc](https://github.com/GStreamer/gstreamer-vaapi/blob/master/gst/vaapi/gstvaapiencode_vp9.c) | ? |
 | AV1   | [av1enc](https://gstreamer.freedesktop.org/documentation/aom/av1enc.html?gi-language=c) | ? | [nvav1enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvav1enc.html?gi-language=c) |
-| H264  | [x264enc](https://gstreamer.freedesktop.org/documentation/x264/index.html?gi-language=c) | [vaapih264enc](https://gstreamer.freedesktop.org/documentation/va/vah264enc.html?gi-language=c) | [nvautogpuh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvautogpuh264enc.html?gi-language=c) / [nvh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh264enc.html?gi-language=c) |
-| H265  | [x265enc](https://gstreamer.freedesktop.org/documentation/x265/index.html?gi-language=c) | [vaapih265enc](https://gstreamer.freedesktop.org/documentation/va/vah265enc.html?gi-language=c) | [nvh265enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh265enc.html?gi-language=c) |
+| H264  | [x264enc](https://gstreamer.freedesktop.org/documentation/x264/index.html?gi-language=c) | [vah264enc](https://gstreamer.freedesktop.org/documentation/va/vah264enc.html?gi-language=c) | [nvautogpuh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvautogpuh264enc.html?gi-language=c) / [nvh264enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh264enc.html?gi-language=c) |
+| H265  | [x265enc](https://gstreamer.freedesktop.org/documentation/x265/index.html?gi-language=c) | [vah265enc](https://gstreamer.freedesktop.org/documentation/va/vah265enc.html?gi-language=c) | [nvh265enc](https://gstreamer.freedesktop.org/documentation/nvcodec/nvh265enc.html?gi-language=c) |
 
 
 ## WebRTC Audio {#audio}


### PR DESCRIPTION
Originally based on https://github.com/m1k1o/neko/pull/117 , I went through the hassle and tuned the parameters to make it work. I've tested the software and NVidia encoder paths. The update to 3.1.0 made it even easier, with updated dependencies.

Note that H265 decoding is poorly supported in Linux browsers, but works fine on Android / Chrome or Mac. Part of the journey was trying to make it work in my desktop browser, but I've failed with my setup. That's also the reason I won't be using this myself at the moment, but maybe in near future? It is possible that with AMD GPU and Chrome it can be made functional. Anyway, I thought since it was already done, someone may appreciate this.

While trying to update the legacy pipelines with the H265 variants, I've discovered that the used VAAPI plugin was merged into GStreamer (plugins-bad) and is deprecated. I've tried to make it so that the result uses the new plugin and is mostly consistent with the rest of the H26x pipelines, but since I own an NVidia GPU, I can't try the VAAPI encoders (only VAAPI decoding driver is available for NVidia GPUs).

Possible resolutions:
1. Merge as suggested, ideally after someone with a different GPU confirms it is working (current branch)
2. Drop the changes to the H264 pipeline and leave the H265 as is until someone provides fixes
3. Drop the changes to the H264 pipeline and use the vaapih265enc for H265 instead (still untested from my side)
4. Drop the changes to the H264 pipeline and drop the support for VAAPI backed H265