### PR TITLE
Add local development setup to docs

### DIFF
--- a/webpage/docs/developer-guide/build.md
+++ b/webpage/docs/developer-guide/build.md
@@ -1,46 +1,44 @@
 ---
-description: Building Neko from source
+description: Building the Neko frontend and backend from source
 ---
 
-# Building From Source
+# Building from Source
 
-This guide walks you through the process of setting up Neko on your local machine or server.
+This page covers building the frontend and backend binaries from source. The Dockerfiles in the repository are the authoritative reference for required dependencies.
 
-Start by cloning the Neko Git repository to your machine:
+## Frontend
 
-```bash
-git clone https://github.com/m1k1o/neko.git
-cd neko
-```
-
-## Building the Frontend {#frontend}
-
-Prerequisites for building the frontend:
-- [node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/)
-
-Navigate to the `client` directory and install the dependencies:
+**Requires:** [Node.js](https://nodejs.org/) 18+
 
 ```bash
-cd client;
-npm install;
-npm run build;
+cd client
+npm install
+npm run build
 ```
 
-The `npm run build` command will create a production build of the frontend in the `client/build` directory.
+The production build is written to `client/dist/`.
 
-## Building the Server {#server}
+## Backend
 
-Prerequisites for building the server:
-- [go](https://golang.org/) (version 1.18 or higher)
-- Dependencies for building the server:
-  ```bash
-  sudo apt-get install -y --no-install-recommends libx11-dev libxrandr-dev libxtst-dev libgtk-3-dev libxcvt-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
-  ```
-Navigate to the `server` directory and build the server:
+**Requires:** [Go](https://golang.org/) 1.25+ and the following system libraries (Debian/Ubuntu):
 
 ```bash
-cd server;
-./build;
+apt-get install -y --no-install-recommends \
+    libx11-dev libxrandr-dev libxtst-dev libgtk-3-dev libxcvt-dev \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 ```
 
-This will create a binary file named `neko` in the `bin` directory along with `plugins` that were built with the server.
+Then build:
+
+```bash
+cd server
+./build
+```
+
+The binary is written to `server/bin/neko`, with any plugins in `server/bin/plugins/`.
+
+Pass `core` to skip building plugins:
+
+```bash
+./build core
+```

--- a/webpage/docs/developer-guide/development.md
+++ b/webpage/docs/developer-guide/development.md
@@ -1,0 +1,100 @@
+---
+description: Running Neko locally for development
+slug: /developer-guide/development
+---
+
+# Local Development
+
+The fastest way to contribute to Neko is to run the backend in Docker and the frontend locally with hot reload. No need to rebuild the whole Docker image on every change.
+
+The only prerequisite is [Docker](https://docs.docker.com/get-docker/).
+
+Start by cloning the repository:
+
+```bash
+git clone https://github.com/m1k1o/neko.git
+cd neko
+```
+
+## Backend {#backend}
+
+All backend dev scripts live in `server/dev/`.
+
+### First-time setup
+
+Build the required Docker images (only needed once, or after major dependency changes):
+
+```bash
+cd server/dev
+./build
+```
+
+### Starting the server
+
+```bash
+cd server/dev
+./start
+```
+
+This starts the neko backend inside Docker and exposes it on port **3000**. The container is named `neko_server_dev` and is kept running in the foreground.
+
+You can pass `nvidia` or `intel` as an argument to enable GPU acceleration:
+
+```bash
+./start nvidia
+./start intel
+```
+
+### Applying backend changes (live rebuild)
+
+After editing Go source files, rebuild and hot-swap the binary into the running container **without restarting Docker**:
+
+```bash
+# in a new terminal
+cd server/dev
+./rebuild
+```
+
+`./rebuild` compiles the server, copies the new binary (and any plugins) into the running `neko_server_dev` container, then tells supervisord to restart only the neko process - the full Docker image is never rebuilt.
+
+## Frontend {#frontend}
+
+All frontend dev scripts live in `client/dev/`.
+
+### Installing dependencies
+
+Dependencies are installed automatically the first time you run `./serve`. To install them manually (or to force a reinstall), run:
+
+```bash
+cd client/dev
+./serve -i
+```
+
+Alternatively, use the provided npm wrapper that runs inside Docker:
+
+```bash
+cd client/dev
+./npm install
+```
+
+### Starting the dev server with hot reload
+
+```bash
+cd client/dev
+./serve
+```
+
+This starts the Vue dev server on port **3001**, proxying API calls to the backend on port **3000**. Any change you save to a file under `client/src/` is reflected in the browser instantly - no page reload required.
+
+| Service | URL |
+|---------|-----|
+| Backend (Docker) | `http://localhost:3000` |
+| Frontend (hot reload) | `http://localhost:3001` |
+
+## Typical workflow
+
+1. **Terminal 1** - start the backend: `cd server/dev && ./start`
+2. **Terminal 2** - start the frontend: `cd client/dev && ./serve`
+3. Open `http://localhost:3001` in your browser.
+4. Edit frontend files → browser updates automatically.
+5. Edit backend files → run `cd server/dev && ./rebuild` in **Terminal 3** to apply changes.

--- a/webpage/sidebars.ts
+++ b/webpage/sidebars.ts
@@ -73,6 +73,7 @@ const sidebars: SidebarsConfig = {
           link: { type: "doc", id: "developer-guide/README" },
           items: [
             'developer-guide/repository-structure',
+            'developer-guide/development',
             'developer-guide/build',
             {
               type: 'link',

--- a/webpage/src/pages/contributing.md
+++ b/webpage/src/pages/contributing.md
@@ -21,7 +21,7 @@ If you're a developer and want to contribute code to Neko, follow these steps:
 
 1. **Fork the [project](https://github.com/m1k1o/neko)**: Create a personal copy of the repository by [forking it](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) to your GitHub account.
 
-2. **Edit files in your branch**: Make your changes in a new branch created from the `master` branch. Ensure your changes are well-documented and tested.
+2. **Edit files in your branch**: Set up your local environment using the [Local Development](/docs/v3/developer-guide/development) guide, then make your changes in a new branch created from the `master` branch. Ensure your changes are well-documented and tested.
 
 3. **Submit a [pull request](https://github.com/m1k1o/neko/pulls)**: Once your changes are ready, submit a pull request with a detailed explanation of the improvements and any relevant information for the reviewers.
 


### PR DESCRIPTION
Build guide is actually the Dockerfile itself. This is meant for new users to run locally neko and be able to contribute.