### PR TITLE
fix: correct LegacyIsHost boolean logic

### DIFF
--- a/server/internal/session/session.go
+++ b/server/internal/session/session.go
@@ -76,7 +76,8 @@ func (session *SessionCtx) IsHost() bool {
 // only needed for legacy webrtc handler
 func (session *SessionCtx) LegacyIsHost() bool {
 	implicitHosting := session.manager.Settings().ImplicitHosting
-	return !(!implicitHosting && !session.manager.isHost(session)) || (implicitHosting && !session.profile.CanHost)
+	return !((!implicitHosting && !session.manager.isHost(session)) ||
+		(implicitHosting && !session.profile.CanHost))
 }
 
 func (session *SessionCtx) SetAsHost() {

--- a/server/internal/session/session.go
+++ b/server/internal/session/session.go
@@ -75,9 +75,14 @@ func (session *SessionCtx) IsHost() bool {
 
 // only needed for legacy webrtc handler
 func (session *SessionCtx) LegacyIsHost() bool {
-	implicitHosting := session.manager.Settings().ImplicitHosting
-	return !((!implicitHosting && !session.manager.isHost(session)) ||
-		(implicitHosting && !session.profile.CanHost))
+	settings := session.manager.Settings()
+	if !session.profile.CanHost || session.PrivateModeEnabled() {
+		return false
+	}
+	if settings.LockedControls && !session.profile.IsAdmin {
+		return false
+	}
+	return settings.ImplicitHosting || session.manager.isHost(session)
 }
 
 func (session *SessionCtx) SetAsHost() {


### PR DESCRIPTION
`LegacyIsHost()` contained a precedence bug: the outer `!` only negated the first sub-expression, leaving `|| (implicitHosting && !CanHost)` always short-circuiting to `true` when `ImplicitHosting` is set. Any authenticated member could send legacy WebRTC data-channel opcodes (`OP_MOVE`, `OP_KEY_*`) regardless of their `CanHost` profile flag.

Thanks to @KasperBuilds for reporting this.