### PR TITLE
fix(filetransfer): allow non-admin file uploads and downloads

### DIFF
--- a/client/src/components/files.vue
+++ b/client/src/components/files.vue
@@ -9,7 +9,7 @@
         <i :class="fileIcon(item)" />
         <p class="file-name" :title="item.name">{{ item.name }}</p>
         <p class="file-size">{{ fileSize(item.size) }}</p>
-        <i v-if="item.type !== 'dir'" class="fas fa-download download" @click="download(item)" />
+        <i v-if="item.type !== 'dir' && canDownload" class="fas fa-download download" @click="download(item)" />
       </div>
     </div>
     <div class="transfer-area">
@@ -73,6 +73,7 @@
         </div>
       </div>
       <div
+        v-if="canUpload"
         class="upload-area"
         :class="{ 'upload-area-drag': uploadAreaDrag }"
         @dragover.prevent="uploadAreaDrag = true"
@@ -280,6 +281,14 @@
   })
   export default class extends Vue {
     public uploadAreaDrag: boolean = false
+
+    get canDownload() {
+      return this.$accessor.user.admin || this.$accessor.files.userDownload
+    }
+
+    get canUpload() {
+      return this.$accessor.user.admin || this.$accessor.files.userUpload
+    }
 
     get cwd() {
       return this.$accessor.files.cwd

--- a/client/src/components/side.vue
+++ b/client/src/components/side.vue
@@ -94,9 +94,19 @@
     },
   })
   export default class extends Vue {
+    get canDownload() {
+      return this.$accessor.user.admin || this.$accessor.files.userDownload
+    }
+
+    get canUpload() {
+      return this.$accessor.user.admin || this.$accessor.files.userUpload
+    }
+
     get filetransferAllowed() {
       return (
-        this.$accessor.remote.fileTransfer && (this.$accessor.user.admin || !this.$accessor.isLocked('file_transfer'))
+        this.$accessor.remote.fileTransfer &&
+        (this.$accessor.user.admin || !this.$accessor.isLocked('file_transfer')) &&
+        (this.canDownload || this.canUpload)
       )
     }
 

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -361,9 +361,11 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
   /////////////////////////////
   // File Transfer Events
   /////////////////////////////
-  protected [EVENT.FILETRANSFER.LIST]({ cwd, files }: FileTransferListPayload) {
+  protected [EVENT.FILETRANSFER.LIST]({ cwd, user_download, user_upload, files }: FileTransferListPayload) {
     this.$accessor.files.setCwd(cwd)
     this.$accessor.files.setFileList(files)
+    this.$accessor.files.setUserDownload(user_download)
+    this.$accessor.files.setUserUpload(user_upload)
   }
 
   /////////////////////////////

--- a/client/src/neko/messages.ts
+++ b/client/src/neko/messages.ts
@@ -204,6 +204,8 @@ export interface FileTransferListMessage extends WebSocketMessage, FileTransferL
 
 export interface FileTransferListPayload {
   cwd: string
+  user_download: boolean
+  user_upload: boolean
   files: FileListItem[]
 }
 

--- a/client/src/store/files.ts
+++ b/client/src/store/files.ts
@@ -7,6 +7,8 @@ export const state = () => ({
   cwd: '',
   files: [] as FileListItem[],
   transfers: [] as FileTransfer[],
+  userDownload: false,
+  userUpload: false,
 })
 
 export const getters = getterTree(state, {
@@ -20,6 +22,14 @@ export const mutations = mutationTree(state, {
 
   _setFileList(state, files: FileListItem[]) {
     state.files = files
+  },
+
+  _setUserDownload(state, val: boolean) {
+    state.userDownload = val
+  },
+
+  _setUserUpload(state, val: boolean) {
+    state.userUpload = val
   },
 
   _addTransfer(state, transfer: FileTransfer) {
@@ -40,6 +50,14 @@ export const actions = actionTree(
 
     setFileList(store, files: FileListItem[]) {
       accessor.files._setFileList(files)
+    },
+
+    setUserDownload(store, val: boolean) {
+      accessor.files._setUserDownload(val)
+    },
+
+    setUserUpload(store, val: boolean) {
+      accessor.files._setUserUpload(val)
     },
 
     addTransfer(store, transfer: FileTransfer) {

--- a/server/internal/http/legacy/message/messages.go
+++ b/server/internal/http/legacy/message/messages.go
@@ -109,9 +109,11 @@ type EmoteSend struct {
 }
 
 type FileTransferList struct {
-	Event string               `json:"event"`
-	Cwd   string               `json:"cwd"`
-	Files []types.FileListItem `json:"files"`
+	Event        string               `json:"event"`
+	Cwd          string               `json:"cwd"`
+	UserDownload bool                 `json:"user_download"`
+	UserUpload   bool                 `json:"user_upload"`
+	Files        []types.FileListItem `json:"files"`
 }
 
 type Admin struct {

--- a/server/internal/http/legacy/wstoclient.go
+++ b/server/internal/http/legacy/wstoclient.go
@@ -607,9 +607,11 @@ func (s *session) wsToClient(msg []byte) error {
 		}
 
 		return s.toClient(&oldMessage.FileTransferList{
-			Event: oldEvent.FILETRANSFER_LIST,
-			Cwd:   request.RootDir,
-			Files: files,
+			Event:        oldEvent.FILETRANSFER_LIST,
+			Cwd:          request.RootDir,
+			UserDownload: request.UserDownload,
+			UserUpload:   request.UserUpload,
+			Files:        files,
 		})
 
 	// Screen Events

--- a/server/internal/plugins/filetransfer/config.go
+++ b/server/internal/plugins/filetransfer/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	Enabled         bool
 	RootDir         string
 	RefreshInterval time.Duration
+	UserDownload    bool
+	UserUpload      bool
 }
 
 func (Config) Init(cmd *cobra.Command) error {
@@ -27,6 +29,16 @@ func (Config) Init(cmd *cobra.Command) error {
 
 	cmd.PersistentFlags().Duration("filetransfer.refresh_interval", 30*time.Second, "interval to refresh file list")
 	if err := viper.BindPFlag("filetransfer.refresh_interval", cmd.PersistentFlags().Lookup("filetransfer.refresh_interval")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("filetransfer.user_download", false, "allow non-admin users to download files")
+	if err := viper.BindPFlag("filetransfer.user_download", cmd.PersistentFlags().Lookup("filetransfer.user_download")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("filetransfer.user_upload", false, "allow non-admin users to upload files")
+	if err := viper.BindPFlag("filetransfer.user_upload", cmd.PersistentFlags().Lookup("filetransfer.user_upload")); err != nil {
 		return err
 	}
 
@@ -50,6 +62,8 @@ func (s *Config) Set() {
 	rootDir := viper.GetString("filetransfer.dir")
 	s.RootDir = filepath.Clean(rootDir)
 	s.RefreshInterval = viper.GetDuration("filetransfer.refresh_interval")
+	s.UserDownload = viper.GetBool("filetransfer.user_download")
+	s.UserUpload = viper.GetBool("filetransfer.user_upload")
 
 	// v2 config
 

--- a/server/internal/plugins/filetransfer/manager.go
+++ b/server/internal/plugins/filetransfer/manager.go
@@ -103,9 +103,11 @@ func (m *Manager) broadcastUpdate() {
 	m.mu.RUnlock()
 
 	m.sessions.Broadcast(FILETRANSFER_UPDATE, Message{
-		Enabled: m.config.Enabled,
-		RootDir: m.config.RootDir,
-		Files:   fileList,
+		Enabled:      m.config.Enabled,
+		RootDir:      m.config.RootDir,
+		UserDownload: m.config.UserDownload,
+		UserUpload:   m.config.UserUpload,
+		Files:        fileList,
 	})
 }
 
@@ -115,9 +117,11 @@ func (m *Manager) sendUpdate(session types.Session) {
 	m.mu.RUnlock()
 
 	session.Send(FILETRANSFER_UPDATE, Message{
-		Enabled: m.config.Enabled,
-		RootDir: m.config.RootDir,
-		Files:   fileList,
+		Enabled:      m.config.Enabled,
+		RootDir:      m.config.RootDir,
+		UserDownload: m.config.UserDownload,
+		UserUpload:   m.config.UserUpload,
+		Files:        fileList,
 	})
 }
 

--- a/server/internal/plugins/filetransfer/manager.go
+++ b/server/internal/plugins/filetransfer/manager.go
@@ -251,6 +251,10 @@ func (m *Manager) downloadFileHandler(w http.ResponseWriter, r *http.Request) er
 		return utils.HttpForbidden("file transfer is disabled")
 	}
 
+	if !session.Profile().IsAdmin && !m.config.UserDownload {
+		return utils.HttpForbidden("file download is not allowed for non-admin users")
+	}
+
 	filename := r.URL.Query().Get("filename")
 	badChars, err := regexp.MatchString(`(?m)\.\.(?:\/|$)`, filename)
 	if filename == "" || badChars || err != nil {
@@ -283,6 +287,10 @@ func (m *Manager) uploadFileHandler(w http.ResponseWriter, r *http.Request) erro
 
 	if !enabled {
 		return utils.HttpForbidden("file transfer is disabled")
+	}
+
+	if !session.Profile().IsAdmin && !m.config.UserUpload {
+		return utils.HttpForbidden("file upload is not allowed for non-admin users")
 	}
 
 	err = r.ParseMultipartForm(multipartFormMaxMemory)

--- a/server/internal/plugins/filetransfer/manager.go
+++ b/server/internal/plugins/filetransfer/manager.go
@@ -208,8 +208,8 @@ func (m *Manager) Shutdown() error {
 }
 
 func (m *Manager) Route(r types.Router) {
-	r.With(auth.AdminsOnly).Get("/", m.downloadFileHandler)
-	r.With(auth.AdminsOnly).Post("/", m.uploadFileHandler)
+	r.Get("/", m.downloadFileHandler)
+	r.Post("/", m.uploadFileHandler)
 }
 
 func (m *Manager) WebSocketHandler(session types.Session, msg types.WebSocketMessage) bool {

--- a/server/internal/plugins/filetransfer/types.go
+++ b/server/internal/plugins/filetransfer/types.go
@@ -11,9 +11,11 @@ const (
 )
 
 type Message struct {
-	Enabled bool   `json:"enabled"`
-	RootDir string `json:"root_dir"`
-	Files   []Item `json:"files"`
+	Enabled      bool   `json:"enabled"`
+	RootDir      string `json:"root_dir"`
+	UserDownload bool   `json:"user_download"`
+	UserUpload   bool   `json:"user_upload"`
+	Files        []Item `json:"files"`
 }
 
 type ItemType string

--- a/webpage/docs/configuration/plugins.md
+++ b/webpage/docs/configuration/plugins.md
@@ -59,11 +59,15 @@ The file transfer plugin is a simple pre-loaded internal plugin that allows you 
     type: 'duration',
     defaultValue: '30s',
   },
+  'filetransfer.user_download': false,
+  'filetransfer.user_upload': false,
 }} />
 
 - <Def id="filetransfer.enabled" /> enables the file transfer support. If set to `false`, the file transfer is disabled.
 - <Def id="filetransfer.dir" /> refers to the directory where the files are stored.
 - <Def id="filetransfer.refresh_interval" /> refers to the interval at which the file list is refreshed.
+- <Def id="filetransfer.user_download" /> allows non-admin users to download files. If set to `false` (default), only admins can download files.
+- <Def id="filetransfer.user_upload" /> allows non-admin users to upload files. If set to `false` (default), only admins can upload files.
 
 The file transfer plugin extends user profile and room settings by adding the following fields:
 


### PR DESCRIPTION
### Use Case & Problem
In collaborative team environments, multiple team members (non-admins) use Neko to browse web applications and run data exports (e.g. CSV, XLSX, PDF reports). Once a file is downloaded inside Neko (`/home/neko/Downloads`), team members need to save that file to their local laptops via Neko's right sidebar (`Files` tab).

Currently in Neko v3.1, non-admin members receive a `403 Forbidden` (`session is not admin` / `Request failed with status code 403`) error when clicking any file in the `Files` tab or dragging a file to upload.

Requiring full Room Admin privileges just to download an export file forces room owners to grant full administrative override rights to every team member.

### Root Cause
In `server/internal/plugins/filetransfer/manager.go`, `Route()` wraps file transfer GET/POST endpoints with `r.With(auth.AdminsOnly)`:

```go
func (m *Manager) Route(r types.Router) {
	r.With(auth.AdminsOnly).Get("/", m.downloadFileHandler)
	r.With(auth.AdminsOnly).Post("/", m.uploadFileHandler)
}