### PR TITLE
Add ?scroll query param to set scroll sensitivity on load

### DIFF
--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -206,6 +206,11 @@
       return Math.max(0.0, Math.min(!isNaN(numberParam) ? numberParam * 100 : 100, 100))
     }
 
+    get scroll() {
+      const numberParam = parseInt(new URL(location.href).searchParams.get('scroll') || '', 10)
+      return Math.max(1, Math.min(!isNaN(numberParam) ? numberParam : 10, 100))
+    }
+
     get isCastMode() {
       return !!new URL(location.href).searchParams.get('cast')
     }
@@ -226,6 +231,13 @@
     onVolume(volume: number) {
       if (new URL(location.href).searchParams.has('volume')) {
         this.$accessor.video.setVolume(volume)
+      }
+    }
+
+    @Watch('scroll', { immediate: true })
+    onScroll(scroll: number) {
+      if (new URL(location.href).searchParams.has('scroll')) {
+        this.$accessor.settings.setScroll(scroll)
       }
     }
 

--- a/webpage/docs/customization/ui.md
+++ b/webpage/docs/customization/ui.md
@@ -52,6 +52,7 @@ You can use query parameters to customize the Neko web interface. These paramete
 | `?cast=1`          | Hides all controls and shows only the video.               |
 | `?embed=1`         | Hides most additional components and shows only the video. |
 | `?volume=<0-1>`    | Sets the volume to the given value (between 0 and 1).      |
+| `?scroll=<1-100>`  | Sets the scroll sensitivity to the given value (1-100).    |
 | `?lang=<language>` | Sets the language to the given value.                      |
 | `?show_side=1`     | Shows the sidebar on startup.                              |
 | `?mute_chat=1`     | Mutes the chat on startup.                                 |


### PR DESCRIPTION
Closes #607.

Scroll sensitivity is only reachable through the settings panel, which isn't great if you're stuck at the default (10) and can't get to the gear icon, e.g. in `?cast=1` mode as mentioned in the issue.

This adds a `?scroll=<1-100>` param that mirrors how `?volume` already works: on load it applies the value through the existing `setScroll` mutation, which also persists it to localStorage, so it keeps sticking on later visits without the param.

Docs table in `webpage/docs/customization/ui.md` updated to list it alongside the other query params.