### PR TITLE
feat: add openinapp plugin to open chat links in shared neko instance

### DIFF
--- a/client/src/components/chat.vue
+++ b/client/src/components/chat.vue
@@ -18,7 +18,7 @@
               <span>{{ member(message.id).displayname }}</span>
               <span class="timestamp">{{ timestamp(message.created) }}</span>
             </div>
-            <neko-markdown class="content-body" :source="message.content" />
+            <neko-markdown class="content-body" :source="message.content" :open-in-app="$accessor.remote.hosting && $accessor.openinapp.enabled" />
           </div>
         </li>
         <li :key="index" class="event" v-if="message.type === 'event'">
@@ -224,6 +224,11 @@
                 code {
                   display: block;
                 }
+              }
+
+              .open-in-app {
+                margin-left: 0.3em;
+                cursor: pointer;
               }
             }
           }
@@ -460,6 +465,28 @@
         target.parentElement.classList.add('active')
         event.preventDefault()
       }
+
+      if (target.classList.contains('open-in-app')) {
+        const href = target.dataset.href
+        if (href) {
+          this.$accessor.openinapp.sendOpenLink(href)
+        }
+        event.preventDefault()
+      }
+
+      if (
+        this.$accessor.settings.links_in_app &&
+        this.$accessor.openinapp.enabled &&
+        this.$accessor.remote.hosting &&
+        target.tagName.toLowerCase() === 'a'
+      ) {
+        const href = target.getAttribute('href')
+        if (href) {
+          this.$accessor.openinapp.sendOpenLink(href)
+          event.preventDefault()
+        }
+      }
+
     }
 
     onKeyDown(event: KeyboardEvent) {

--- a/client/src/components/chat.vue
+++ b/client/src/components/chat.vue
@@ -18,7 +18,11 @@
               <span>{{ member(message.id).displayname }}</span>
               <span class="timestamp">{{ timestamp(message.created) }}</span>
             </div>
-            <neko-markdown class="content-body" :source="message.content" :open-in-app="$accessor.remote.hosting && $accessor.openinapp.enabled" />
+            <neko-markdown
+              class="content-body"
+              :source="message.content"
+              :open-in-app="$accessor.remote.hosting && $accessor.openinapp.enabled"
+            />
           </div>
         </li>
         <li :key="index" class="event" v-if="message.type === 'event'">
@@ -486,7 +490,6 @@
           event.preventDefault()
         }
       }
-
     }
 
     onKeyDown(event: KeyboardEvent) {

--- a/client/src/components/markdown.ts
+++ b/client/src/components/markdown.ts
@@ -136,12 +136,21 @@ const rules: MarkdownRules = {
       }
     },
     html(node, output, state) {
-      return htmlTag(
+      const href = md.sanitizeUrl(node.target) as string
+      const link = htmlTag(
         'a',
         output(node.content, state),
         { href: md.sanitizeUrl(node.target) as string, target: '_blank' },
         state,
       )
+      if(!state.openInApp) return link
+      const inAppIcon = htmlTag(
+        'i', 
+        '',
+        { class: 'open-in-app fas fa-arrow-up-right-from-square', 'data-href': href }, 
+        state,
+      )
+      return link + inAppIcon
     },
   },
   url: {
@@ -158,12 +167,21 @@ const rules: MarkdownRules = {
       }
     },
     html(node, output, state) {
-      return htmlTag(
+      const href = md.sanitizeUrl(node.target) as string
+      const link = htmlTag(
         'a',
         output(node.content, state),
         { href: md.sanitizeUrl(node.target) as string, target: '_blank' },
         state,
       )
+      if(!state.openInApp) return link
+      const inAppIcon = htmlTag(
+        'i', 
+        '',
+        { class: 'open-in-app fas fa-arrow-right-to-bracket', 'data-href': href }, 
+        state,
+      )
+      return link + inAppIcon
     },
   },
   strike: {
@@ -257,12 +275,16 @@ export default class extends Vue {
   @Prop({ required: true })
   source!: string
 
+  @Prop({ default: false })
+  openInApp!: boolean
+
   render(h: any) {
     const state: MarkdownState = {
       inline: true,
       inQuote: false,
       escapeHTML: true,
       cssModuleNames: null,
+      openInApp: this.openInApp,
     }
     return h({ template: `<div>${htmlOutput(parser(this.source, state), state)}</div>` })
   }

--- a/client/src/components/markdown.ts
+++ b/client/src/components/markdown.ts
@@ -143,11 +143,11 @@ const rules: MarkdownRules = {
         { href: md.sanitizeUrl(node.target) as string, target: '_blank' },
         state,
       )
-      if(!state.openInApp) return link
+      if (!state.openInApp) return link
       const inAppIcon = htmlTag(
-        'i', 
+        'i',
         '',
-        { class: 'open-in-app fas fa-arrow-up-right-from-square', 'data-href': href }, 
+        { class: 'open-in-app fas fa-arrow-up-right-from-square', 'data-href': href },
         state,
       )
       return link + inAppIcon
@@ -174,11 +174,11 @@ const rules: MarkdownRules = {
         { href: md.sanitizeUrl(node.target) as string, target: '_blank' },
         state,
       )
-      if(!state.openInApp) return link
+      if (!state.openInApp) return link
       const inAppIcon = htmlTag(
-        'i', 
+        'i',
         '',
-        { class: 'open-in-app fas fa-arrow-right-to-bracket', 'data-href': href }, 
+        { class: 'open-in-app fas fa-arrow-right-to-bracket', 'data-href': href },
         state,
       )
       return link + inAppIcon

--- a/client/src/components/settings.vue
+++ b/client/src/components/settings.vue
@@ -35,6 +35,13 @@
           <span />
         </label>
       </li>
+      <li v-if="$accessor.openinapp.enabled">
+        <span>Always open Links in App</span>
+        <label class="switch">
+          <input type="checkbox" v-model="links_in_app" />
+          <span />
+        </label>
+      </li>
       <li>
         <span>{{ $t('setting.keyboard_layout') }}</span>
         <label class="select">
@@ -356,6 +363,14 @@
 
     set chat_sound(value: boolean) {
       this.$accessor.settings.setSound(value)
+    }
+
+    get links_in_app() {
+      return this.$accessor.settings.links_in_app
+    }
+
+    set links_in_app(value: boolean) {
+      this.$accessor.settings.setLinksInApp(value)
     }
 
     get keyboard_layouts_list() {

--- a/client/src/neko/events.ts
+++ b/client/src/neko/events.ts
@@ -45,6 +45,10 @@ export const EVENT = {
     LIST: 'filetransfer/list',
     REFRESH: 'filetransfer/refresh',
   },
+  OPENINAPP: {
+    INIT: 'openinapp/init',
+    OPENLINK: 'openinapp/openlink',
+  },
   SCREEN: {
     CONFIGURATIONS: 'screen/configurations',
     RESOLUTION: 'screen/resolution',
@@ -78,6 +82,7 @@ export type WebSocketEvents =
   | SignalEvents
   | ChatEvents
   | FileTransferEvents
+  | OpenInAppEvents
   | ScreenEvents
   | BroadcastEvents
   | AdminEvents
@@ -103,6 +108,8 @@ export type SignalEvents =
 export type ChatEvents = typeof EVENT.CHAT.MESSAGE | typeof EVENT.CHAT.EMOTE
 
 export type FileTransferEvents = typeof EVENT.FILETRANSFER.LIST | typeof EVENT.FILETRANSFER.REFRESH
+
+export type OpenInAppEvents = typeof EVENT.OPENINAPP.INIT | typeof EVENT.OPENINAPP.OPENLINK
 
 export type ScreenEvents = typeof EVENT.SCREEN.CONFIGURATIONS | typeof EVENT.SCREEN.RESOLUTION | typeof EVENT.SCREEN.SET
 

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -376,6 +376,13 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
   }
 
   /////////////////////////////
+  // Open in App Events
+  /////////////////////////////
+  protected [EVENT.OPENINAPP.INIT]({ enabled }: { enabled: boolean }) {
+    this.$accessor.openinapp.setEnabled(enabled)
+  }
+
+  /////////////////////////////
   // Screen Events
   /////////////////////////////
   protected [EVENT.SCREEN.CONFIGURATIONS]({ configurations }: ScreenConfigurationsPayload) {

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -8,6 +8,7 @@ import { get, set } from '~/utils/localstorage'
 import * as video from './video'
 import * as chat from './chat'
 import * as files from './files'
+import * as openinapp from './openinapp'
 import * as remote from './remote'
 import * as user from './user'
 import * as settings from './settings'
@@ -111,7 +112,7 @@ export const storePattern = {
   mutations,
   actions,
   getters,
-  modules: { video, chat, files, user, remote, settings, client, emoji },
+  modules: { video, chat, files, openinapp, user, remote, settings, client, emoji },
 }
 
 Vue.use(Vuex)

--- a/client/src/store/openinapp.ts
+++ b/client/src/store/openinapp.ts
@@ -1,0 +1,29 @@
+import { getterTree, mutationTree, actionTree } from 'typed-vuex'
+import { EVENT } from '~/neko/events'
+import { accessor } from '~/store'
+
+export const namespaced = true
+
+export const state = () => ({
+  enabled: false,
+})
+
+export const getters = getterTree(state, {
+  //
+})
+
+export const mutations = mutationTree(state, {
+  setEnabled(state, enabled: boolean) {
+    state.enabled = enabled
+  }
+})
+
+export const actions = actionTree(
+  { state, getters, mutations },
+  {
+    sendOpenLink(store, url: string) {
+    if (!accessor.connected) return
+    $client.sendMessage(EVENT.OPENINAPP.OPENLINK, {text: url})
+    }
+  },
+)

--- a/client/src/store/openinapp.ts
+++ b/client/src/store/openinapp.ts
@@ -15,15 +15,15 @@ export const getters = getterTree(state, {
 export const mutations = mutationTree(state, {
   setEnabled(state, enabled: boolean) {
     state.enabled = enabled
-  }
+  },
 })
 
 export const actions = actionTree(
   { state, getters, mutations },
   {
     sendOpenLink(store, url: string) {
-    if (!accessor.connected) return
-    $client.sendMessage(EVENT.OPENINAPP.OPENLINK, {text: url})
-    }
+      if (!accessor.connected) return
+      $client.sendMessage(EVENT.OPENINAPP.OPENLINK, { text: url })
+    },
   },
 )

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -16,6 +16,7 @@ export const state = () => {
     autoplay: get<boolean>('autoplay', true),
     ignore_emotes: get<boolean>('ignore_emotes', false),
     chat_sound: get<boolean>('chat_sound', true),
+    links_in_app: get<boolean>('links_in_app', false),
     keyboard_layout: get<string>('keyboard_layout', 'us'),
 
     keyboard_layouts_list: {} as KeyboardLayouts,
@@ -51,6 +52,11 @@ export const mutations = mutationTree(state, {
   setSound(state, value: boolean) {
     state.chat_sound = value
     set('chat_sound', value)
+  },
+
+  setLinksInApp(state, value: boolean) {
+    state.links_in_app = value
+    set('links_in_app', value)
   },
 
   setKeyboardLayout(state, value: string) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,4 +13,8 @@ services:
       NEKO_WEBRTC_EPR: 52000-52100
       NEKO_WEBRTC_ICELITE: 1
       # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#ip
-      # NEKO_NAT1TO1: <IP_ADDRESS>
+      # NEKO_NAT1TO1: <IP_ADDRESS> 
+      
+      # Open In App Plugin 
+      # NEKO_OPENINAPP_ENABLED: TRUE
+      # NEKO_OPENINAPP_OPEN_COMMAND: firefox -P default 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,4 +13,4 @@ services:
       NEKO_WEBRTC_EPR: 52000-52100
       NEKO_WEBRTC_ICELITE: 1
       # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#ip
-      # NEKO_NAT1TO1: <IP_ADDRESS> 
+      # NEKO_NAT1TO1: <IP_ADDRESS>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,3 @@ services:
       NEKO_WEBRTC_ICELITE: 1
       # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#ip
       # NEKO_NAT1TO1: <IP_ADDRESS> 
-      
-      # Open In App Plugin 
-      # NEKO_OPENINAPP_ENABLED: TRUE
-      # NEKO_OPENINAPP_OPEN_COMMAND: firefox -P default 

--- a/server/internal/http/legacy/wstobackend.go
+++ b/server/internal/http/legacy/wstobackend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/m1k1o/neko/server/internal/api/room"
 	"github.com/m1k1o/neko/server/internal/plugins/chat"
 	"github.com/m1k1o/neko/server/internal/plugins/filetransfer"
+	"github.com/m1k1o/neko/server/internal/plugins/openinapp"
 	"github.com/m1k1o/neko/server/pkg/types"
 	"github.com/m1k1o/neko/server/pkg/types/event"
 	"github.com/m1k1o/neko/server/pkg/types/message"
@@ -198,6 +199,14 @@ func (s *session) wsToBackend(msg []byte) error {
 	// File Transfer Events
 	case oldEvent.FILETRANSFER_REFRESH:
 		return s.toBackend(filetransfer.FILETRANSFER_UPDATE, nil)
+
+	// Open In App Events
+	case openinapp.OPENINAPP_OPENLINK:
+		request := &openinapp.Url{}
+    if err := json.Unmarshal(msg, request); err != nil {
+			return err
+    }
+    return s.toBackend(openinapp.OPENINAPP_OPENLINK, request)
 
 	// Screen Events
 	case oldEvent.SCREEN_RESOLUTION:

--- a/server/internal/http/legacy/wstobackend.go
+++ b/server/internal/http/legacy/wstobackend.go
@@ -206,7 +206,7 @@ func (s *session) wsToBackend(msg []byte) error {
     if err := json.Unmarshal(msg, request); err != nil {
 			return err
     }
-    return s.toBackend(openinapp.OPENINAPP_OPENLINK, request)
+    return s.apiReq(http.MethodPost, "/api/openinapp/openlink", request, nil)
 
 	// Screen Events
 	case oldEvent.SCREEN_RESOLUTION:

--- a/server/internal/http/legacy/wstoclient.go
+++ b/server/internal/http/legacy/wstoclient.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/m1k1o/neko/server/internal/plugins/chat"
 	"github.com/m1k1o/neko/server/internal/plugins/filetransfer"
+	"github.com/m1k1o/neko/server/internal/plugins/openinapp"
 	"github.com/m1k1o/neko/server/pkg/types"
 	"github.com/m1k1o/neko/server/pkg/types/event"
 	"github.com/m1k1o/neko/server/pkg/types/message"
@@ -614,6 +615,21 @@ func (s *session) wsToClient(msg []byte) error {
 			UserDelete:   request.UserDelete,
 			Files:        files,
 		})
+
+	// Open In App Events
+	case openinapp.OPENINAPP_INIT:
+    request := &openinapp.Init{}
+    if err := json.Unmarshal(data.Payload, request); err != nil {
+			return err
+    }
+    return s.toClient(&struct {
+			Event   string `json:"event"`
+			Enabled bool   `json:"enabled"`
+    }{
+			Event:   openinapp.OPENINAPP_INIT,
+			Enabled: request.Enabled,
+    })
+
 
 	// Screen Events
 	case event.SCREEN_UPDATED:

--- a/server/internal/plugins/manager.go
+++ b/server/internal/plugins/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/m1k1o/neko/server/internal/config"
 	"github.com/m1k1o/neko/server/internal/plugins/chat"
 	"github.com/m1k1o/neko/server/internal/plugins/filetransfer"
+	"github.com/m1k1o/neko/server/internal/plugins/openinapp"
 	"github.com/m1k1o/neko/server/pkg/types"
 )
 
@@ -47,6 +48,7 @@ func New(config *config.Plugins) *ManagerCtx {
 	// add built-in plugins
 	manager.plugins.addPlugin(filetransfer.NewPlugin())
 	manager.plugins.addPlugin(chat.NewPlugin())
+	manager.plugins.addPlugin(openinapp.NewPlugin())
 
 	return manager
 }

--- a/server/internal/plugins/openinapp/config.go
+++ b/server/internal/plugins/openinapp/config.go
@@ -1,0 +1,30 @@
+package openinapp
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	Enabled bool
+	OpenCommand string
+}
+
+func (Config) Init(cmd *cobra.Command) error {
+	cmd.PersistentFlags().Bool("openinapp.enabled", false, "whether to enable openinapp plugin")
+	if err := viper.BindPFlag("openinapp.enabled", cmd.PersistentFlags().Lookup("openinapp.enabled")); err != nil {
+		return err
+	}
+	cmd.PersistentFlags().String("openinapp.open_command", "xdg-open", "command used to open URLs inside the app")
+	if err := viper.BindPFlag("openinapp.open_command", cmd.PersistentFlags().Lookup("openinapp.open_command")); err != nil {
+		return err
+	}
+
+
+	return nil
+}
+
+func (s *Config) Set() {
+	s.Enabled = viper.GetBool("openinapp.enabled")
+	s.OpenCommand = viper.GetString("openinapp.open_command")
+}

--- a/server/internal/plugins/openinapp/manager.go
+++ b/server/internal/plugins/openinapp/manager.go
@@ -2,14 +2,17 @@ package openinapp
 
 import (
 	"encoding/json"
-	"os/exec"
+	"net/http"
 	"net/url"
+	"os/exec"
 	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	
+
+	"github.com/m1k1o/neko/server/pkg/auth"
 	"github.com/m1k1o/neko/server/pkg/types"
+	"github.com/m1k1o/neko/server/pkg/utils"
 )
 
 func NewManager(
@@ -29,6 +32,50 @@ type Manager struct {
 	logger   zerolog.Logger
 	config   *Config
 	sessions types.SessionManager
+}
+
+func (m *Manager) Route(r types.Router) {
+	r.Post("/openlink", m.openLinkHandler)
+}
+
+func (m *Manager) openLinkHandler(w http.ResponseWriter, r *http.Request) error {
+	session, ok := auth.GetSession(r)
+	if !ok {
+		return utils.HttpUnauthorized("session not found")
+	}
+
+	if !m.config.Enabled {
+		return utils.HttpForbidden("openinapp is disabled")
+	}
+
+	if !session.IsHost() {
+		return utils.HttpForbidden("only the host can open links")
+	}
+
+	var req Url
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return utils.HttpBadRequest().WithInternalErr(err).Msg("failed to parse request body")
+	}
+
+	parsedUrl, err := url.Parse(req.Text)
+	if err != nil {
+		return utils.HttpBadRequest().WithInternalErr(err).Msg("failed to parse URL")
+	}
+
+	if parsedUrl.Scheme != "http" && parsedUrl.Scheme != "https" {
+		return utils.HttpBadRequest().Msg("URL must use http or https scheme")
+	}
+
+	parts := strings.Fields(m.config.OpenCommand)
+	if len(parts) == 0 {
+		return utils.HttpInternalServerError().Msg("open command is not configured")
+	}
+
+	if err := exec.Command(parts[0], append(parts[1:], parsedUrl.String())...).Start(); err != nil {
+		return utils.HttpInternalServerError().WithInternalErr(err).Msg("failed to start open command")
+	}
+
+	return utils.HttpSuccess(w, nil)
 }
 
 func (m *Manager) WebSocketHandler(session types.Session, msg types.WebSocketMessage) bool {
@@ -71,7 +118,7 @@ func (m *Manager) WebSocketHandler(session types.Session, msg types.WebSocketMes
 			m.logger.Error().Msg("open command is not configured")
 			return true
 		}
-		if err := exec.Command(parts[0], append(parts[1:], parsedUrl.String())...).Start(); err != nil { 
+		if err := exec.Command(parts[0], append(parts[1:], parsedUrl.String())...).Start(); err != nil {
 			m.logger.Error().Err(err).Msg("failed to start open command")
 			// we processed the openlink request, return true
 			return true

--- a/server/internal/plugins/openinapp/manager.go
+++ b/server/internal/plugins/openinapp/manager.go
@@ -48,7 +48,7 @@ func (m *Manager) openLinkHandler(w http.ResponseWriter, r *http.Request) error 
 		return utils.HttpForbidden("openinapp is disabled")
 	}
 
-	if !session.IsHost() {
+	if !session.IsHost() && (!session.Profile().CanHost || !m.sessions.Settings().ImplicitHosting) {
 		return utils.HttpForbidden("only the host can open links")
 	}
 
@@ -76,57 +76,6 @@ func (m *Manager) openLinkHandler(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	return utils.HttpSuccess(w, nil)
-}
-
-func (m *Manager) WebSocketHandler(session types.Session, msg types.WebSocketMessage) bool {
-	switch msg.Event {
-	case OPENINAPP_OPENLINK:
-		if !m.config.Enabled {
-			m.logger.Warn().Msg("openlink request recieved while plugin is disabled")
-			// we processed the openlink request, return true
-			return true
-		}
-
-		var req Url
-		if err := json.Unmarshal(msg.Payload, &req); err != nil {
-			m.logger.Error().Err(err).Msg("failed to unmarshal openlink request")
-			// we processed the openlink request, return true
-			return true
-		}
-
-		if !session.IsHost() {
-			m.logger.Warn().Msg("openlink request by non-host")
-			// we processed the openlink request, return true
-			return true
-		}
-
-		parsedUrl, err := url.Parse(req.Text)
-		if err != nil {
-			m.logger.Error().Err(err).Msg("failed to parse openlink request")
-			// we processed the openlink request, return true
-			return true
-		}
-
-		if !(parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https") {
-			m.logger.Warn().Msg("openlink url does not have valid scheme")
-			// we processed the openlink url, return true
-			return true
-		}
-
-		parts := strings.Fields(m.config.OpenCommand)
-		if len(parts) == 0 {
-			m.logger.Error().Msg("open command is not configured")
-			return true
-		}
-		if err := exec.Command(parts[0], append(parts[1:], parsedUrl.String())...).Start(); err != nil {
-			m.logger.Error().Err(err).Msg("failed to start open command")
-			// we processed the openlink request, return true
-			return true
-		}
-
-		return true
-	}
-	return false
 }
 
 func (m *Manager) Start() error {

--- a/server/internal/plugins/openinapp/manager.go
+++ b/server/internal/plugins/openinapp/manager.go
@@ -1,0 +1,98 @@
+package openinapp
+
+import (
+	"encoding/json"
+	"os/exec"
+	"net/url"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	
+	"github.com/m1k1o/neko/server/pkg/types"
+)
+
+func NewManager(
+	sessions types.SessionManager,
+	config *Config,
+) *Manager {
+	logger := log.With().Str("module", "openinapp").Logger()
+
+	return &Manager{
+		logger:   logger,
+		config:   config,
+		sessions: sessions,
+	}
+}
+
+type Manager struct {
+	logger   zerolog.Logger
+	config   *Config
+	sessions types.SessionManager
+}
+
+func (m *Manager) WebSocketHandler(session types.Session, msg types.WebSocketMessage) bool {
+	switch msg.Event {
+	case OPENINAPP_OPENLINK:
+		if !m.config.Enabled {
+			m.logger.Warn().Msg("openlink request recieved while plugin is disabled")
+			// we processed the openlink request, return true
+			return true
+		}
+
+		var req Url
+		if err := json.Unmarshal(msg.Payload, &req); err != nil {
+			m.logger.Error().Err(err).Msg("failed to unmarshal openlink request")
+			// we processed the openlink request, return true
+			return true
+		}
+
+		if !session.IsHost() {
+			m.logger.Warn().Msg("openlink request by non-host")
+			// we processed the openlink request, return true
+			return true
+		}
+
+		parsedUrl, err := url.Parse(req.Text)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("failed to parse openlink request")
+			// we processed the openlink request, return true
+			return true
+		}
+
+		if !(parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https") {
+			m.logger.Warn().Msg("openlink url does not have valid scheme")
+			// we processed the openlink url, return true
+			return true
+		}
+
+		parts := strings.Fields(m.config.OpenCommand)
+		if len(parts) == 0 {
+			m.logger.Error().Msg("open command is not configured")
+			return true
+		}
+		if err := exec.Command(parts[0], append(parts[1:], parsedUrl.String())...).Start(); err != nil { 
+			m.logger.Error().Err(err).Msg("failed to start open command")
+			// we processed the openlink request, return true
+			return true
+		}
+
+		return true
+	}
+	return false
+}
+
+func (m *Manager) Start() error {
+	// send init message once a user connects
+	m.sessions.OnConnected(func(session types.Session) {
+		session.Send(OPENINAPP_INIT, Init{
+			Enabled: m.config.Enabled,
+		})
+	})
+
+	return nil
+}
+
+func (m *Manager) Shutdown() error {
+	return nil
+}

--- a/server/internal/plugins/openinapp/plugin.go
+++ b/server/internal/plugins/openinapp/plugin.go
@@ -26,7 +26,6 @@ func (p *Plugin) Config() types.PluginConfig {
 func (p *Plugin) Start(m types.PluginManagers) error {
 	p.manager = NewManager(m.SessionManager, p.config)
 	m.ApiManager.AddRouter("/openinapp", p.manager.Route)
-	m.WebSocketManager.AddHandler(p.manager.WebSocketHandler)
 	return p.manager.Start()
 }
 

--- a/server/internal/plugins/openinapp/plugin.go
+++ b/server/internal/plugins/openinapp/plugin.go
@@ -25,6 +25,7 @@ func (p *Plugin) Config() types.PluginConfig {
 
 func (p *Plugin) Start(m types.PluginManagers) error {
 	p.manager = NewManager(m.SessionManager, p.config)
+	m.ApiManager.AddRouter("/openinapp", p.manager.Route)
 	m.WebSocketManager.AddHandler(p.manager.WebSocketHandler)
 	return p.manager.Start()
 }

--- a/server/internal/plugins/openinapp/plugin.go
+++ b/server/internal/plugins/openinapp/plugin.go
@@ -1,0 +1,34 @@
+package openinapp
+
+import (
+	"github.com/m1k1o/neko/server/pkg/types"
+)
+
+type Plugin struct {
+	config  *Config
+	manager *Manager
+}
+
+func NewPlugin() *Plugin {
+	return &Plugin{
+		config: &Config{},
+	}
+}
+
+func (p *Plugin) Name() string {
+	return PluginName
+}
+
+func (p *Plugin) Config() types.PluginConfig {
+	return p.config
+}
+
+func (p *Plugin) Start(m types.PluginManagers) error {
+	p.manager = NewManager(m.SessionManager, p.config)
+	m.WebSocketManager.AddHandler(p.manager.WebSocketHandler)
+	return p.manager.Start()
+}
+
+func (p *Plugin) Shutdown() error {
+	return p.manager.Shutdown()
+}

--- a/server/internal/plugins/openinapp/types.go
+++ b/server/internal/plugins/openinapp/types.go
@@ -1,0 +1,16 @@
+package openinapp
+
+const PluginName = "openinapp"
+
+const (
+	OPENINAPP_INIT    = "openinapp/init"
+	OPENINAPP_OPENLINK = "openinapp/openlink"
+)
+
+type Init struct {
+	Enabled bool `json:"enabled"`
+}
+
+type Url struct {
+	Text string `json:"text"`
+}

--- a/webpage/docs/configuration/plugins.md
+++ b/webpage/docs/configuration/plugins.md
@@ -79,3 +79,19 @@ plugins:
 ```
 
 - `filetransfer.enabled` in the room settings context controls whether the file transfer is enabled for any user in the room, and in the user's profile context controls whether the user can transfer files.
+
+## Open In App Plugin {#openinapp}
+
+The open in app plugin allows users to open links directly from the chat inside the shared neko instance.
+
+<ConfigurationTab options={{
+  'openinapp.enabled': true,
+  'openinapp.open_command': 'xdg-open',
+}} />
+
+- <Def id="openinapp.enabled" /> enables the open in app support.
+  If set to `false`, the feature is hidden from all clients.
+- <Def id="openinapp.open_command" /> is the shell command used to open
+  URLs inside the neko instance. Defaults to `xdg-open`. Can be set to a
+  browser-specific command such as `firefox -P default` depending on
+  the app image in use.


### PR DESCRIPTION
### Open In App Plugin
When enabled users who hold control see an icon next to links posted in chat. Clicking on the icon opens the link inside the neko instance, instead of the users local browser. Optionally, a settings toggle makes clicking on links open them inside the instance.

### Demo

https://github.com/user-attachments/assets/facd51fb-0757-42dc-b3ca-4ac27c5c5edf

### Configuration
```env
NEKO_OPENINAPP_ENABLED: true
NEKO_OPENINAPP_OPEN_COMMAND: xdg-open  # or browser-specific command
```

### How the code works
I implemented a new internal plugin with a WebSocket event (openinapp/openlink). 
I added legacy bridge handlers so v2 clients work too. 
Markdown.ts generates an icon next to links when the plugin is enabled and the user has controls. 
I added a settings toggle that only shows up if the plugin is enabled. When turned on all clicks on links behave like the icon. When triggered the url is passed to the server validated against http or https scheme and then opened with the open_command. The default command is xdg-open although I noticed that this is not installed as a dependency. To work with different container setups the docker config NEKO_OPENINAPP_OPEN_COMMAND exists. 

### Testing
I tested the plugin with the Xfce Desktop and Firefox. For Xfce I used the open_command "xdg-open" after installing it inside the docker container. For Firefox i used open_command "firefox -P default".
I tested different combinations of me having controls, enabling/disabling the plugin and using the toggle setting.
I tested what happens if a user doesn't have controls and sends an open link request via a modified browser.   

Happy to hear any feedback or suggestions for changes.

-Paul