### PR TITLE
Add example Docker Compose configurations for Neko

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Examples
+
+Ready-to-use [Docker Compose](https://docs.docker.com/compose/) configurations for Neko. Each folder is self-contained and can be copied out and run on its own with `docker compose up`. All files are heavily commented, showing available options and linking to the relevant documentation inline.
+
+These are the same examples shown in the [documentation](https://neko.m1k1o.net/docs/v3/installation/examples), kept here so they can be browsed, cloned or downloaded directly from the repository.
+
+| Example | Description |
+| --- | --- |
+| [simple-browser](./simple-browser) | Firefox with commented options for persistent/custom profiles and other available browser images. |
+| [kiosk-browser](./kiosk-browser) | Firefox in kiosk mode that opens a fixed URL on startup (e.g. a streaming service or dashboard). Stateless by default. |
+| [nvidia-browser](./nvidia-browser) | Firefox with Nvidia GPU acceleration, with a commented "encode-only" option. |
+| [intel-browser](./intel-browser) | Firefox with Intel (VAAPI) GPU acceleration, with a commented "encode-only" option. |
+| [raspberry-pi-browser](./raspberry-pi-browser) | Firefox tuned for Raspberry Pi, with a commented hardware-encoding option. |
+| [arm64-browser](./arm64-browser) | Firefox on generic ARM64 hosts, with links to DRM setup and GPU acceleration options. |
+| [turn-server](./turn-server) | A Coturn TURN server running alongside Neko for WebRTC NAT traversal. |
+

--- a/examples/arm64-browser/docker-compose.yaml
+++ b/examples/arm64-browser/docker-compose.yaml
@@ -1,0 +1,33 @@
+# Neko - ARM64 Browser Example
+#
+# Runs Firefox on a generic ARM64 host (e.g. Apple M1/M2 under virtualization,
+# AWS Graviton, Oracle Cloud ARM free tier). The same multi-arch image used
+# on amd64 works here - no special image tag is required.
+#
+# See supported architectures and per-app availability:
+# https://neko.m1k1o.net/docs/v3/installation/docker-images#availability
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    shm_size: "2gb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    environment:
+      NEKO_DESKTOP_SCREEN: '1920x1080@30'
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
+      # NEKO_WEBRTC_NAT1TO1: <your-IP>
+
+      # DRM (Widevine) support is limited on ARM64 and needs extra setup for
+      # protected streaming content:
+      # See: https://neko.m1k1o.net/docs/v3/customization/browsers#arm64-drm
+
+      # GPU ACCELERATION OPTION: if your ARM64 device exposes a V4L2 M2M
+      # hardware encoder (common on SBCs like Raspberry Pi), reuse the same
+      # pipeline as in the Raspberry Pi example:
+      # https://github.com/m1k1o/neko/tree/main/examples/raspberry-pi-browser

--- a/examples/intel-browser/docker-compose.yaml
+++ b/examples/intel-browser/docker-compose.yaml
@@ -1,0 +1,35 @@
+# Neko - Intel Browser Example
+#
+# Runs Firefox with Intel GPU hardware acceleration (VAAPI) for both browser
+# rendering and video encoding. Requires the host to expose /dev/dri and have
+# the Intel graphics driver installed.
+#
+# Other GPU-accelerated flavors are listed here:
+# https://neko.m1k1o.net/docs/v3/installation/docker-images#intel
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/intel-firefox:latest"
+    # ENCODE-ONLY OPTION: if you only want to accelerate video encoding, not
+    # the browser rendering, use the plain firefox image instead:
+    # image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    shm_size: "2gb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    devices:
+      # Required for VAAPI hardware acceleration - gives the container access
+      # to the GPU's render node. The render group is detected automatically.
+      - "/dev/dri:/dev/dri"
+    environment:
+      # The intel-firefox image already sets NEKO_HWENC=vaapi by default.
+      # Uncomment to be explicit, or when using the plain firefox image above
+      # for encode-only acceleration:
+      # NEKO_HWENC: "vaapi"
+      NEKO_DESKTOP_SCREEN: '1920x1080@30'
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
+      # NEKO_WEBRTC_NAT1TO1: <your-IP>

--- a/examples/kiosk-browser/docker-compose.yaml
+++ b/examples/kiosk-browser/docker-compose.yaml
@@ -1,0 +1,34 @@
+# Neko - Kiosk Browser Example
+#
+# Runs Firefox in kiosk mode (no address bar, tabs or browser chrome) and
+# opens a fixed URL automatically on startup. Useful for turning a smart
+# display, thin client or dedicated terminal into an app-like experience.
+#
+# This works by overriding the Firefox supervisor command, see ./firefox.conf
+# and the Supervisord Configuration docs:
+# https://neko.m1k1o.net/docs/v3/customization#supervisord
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    shm_size: "2gb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    volumes:
+      - "./firefox.conf:/etc/neko/supervisord/firefox.conf:ro"
+
+      # NOTE: this setup is intentionally stateless - no profile is persisted,
+      # so cookies and logins are lost every time the container restarts. If
+      # you want the kiosk session to stay logged in across restarts, mount a
+      # persistent profile directory as well:
+      # See: https://neko.m1k1o.net/docs/v3/customization/browsers#persistent-profile
+      # - "./profile:/home/neko/.mozilla/firefox/profile.default"
+    environment:
+      NEKO_DESKTOP_SCREEN: '1280x720@30'
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
+      # NEKO_WEBRTC_NAT1TO1: <your-IP>

--- a/examples/kiosk-browser/firefox.conf
+++ b/examples/kiosk-browser/firefox.conf
@@ -1,0 +1,13 @@
+[program:firefox]
+environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY="%(ENV_DISPLAY)s"
+; Replace <YOUR-KIOSK-URL> with the page to open automatically on startup,
+; e.g. https://www.disneyplus.com/ for a dedicated streaming kiosk.
+command=/usr/bin/firefox --kiosk --no-remote -P default --display=%(ENV_DISPLAY)s -setDefaultBrowser -width 1280 -height 720 <YOUR-KIOSK-URL>
+stopsignal=INT
+autorestart=true
+priority=800
+user=%(ENV_USER)s
+stdout_logfile=/var/log/neko/firefox.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=10
+redirect_stderr=true

--- a/examples/nvidia-browser/docker-compose.yaml
+++ b/examples/nvidia-browser/docker-compose.yaml
@@ -1,0 +1,86 @@
+# Neko - Nvidia Browser Example
+#
+# Runs Firefox with full Nvidia GPU acceleration (both browser rendering and
+# video encoding) using CUDA. Requires the Nvidia Container Toolkit:
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+#
+# Check if your GPU supports hardware encoding:
+# https://developer.nvidia.com/video-encode-decode-gpu-support-matrix
+#
+# Other GPU-accelerated flavors are listed here:
+# https://neko.m1k1o.net/docs/v3/installation/docker-images#nvidia
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/nvidia-firefox:latest"
+    # ENCODE-ONLY OPTION: if you only want to accelerate video encoding, not
+    # the browser rendering, use the plain firefox image instead - see the
+    # matching commented pipeline/env vars further down.
+    # image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    shm_size: "2gb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    environment:
+      # ENCODE-ONLY OPTION: uncomment these two when using the plain firefox
+      # image above, so the container can still see the GPU for encoding.
+      # NVIDIA_VISIBLE_DEVICES: all
+      # NVIDIA_DRIVER_CAPABILITIES: all
+
+      # `nvautogpuh264enc` (GStreamer 1.22+) is recommended for NVIDIA driver
+      # 590+; it auto-selects CUDA or system memory. On older drivers or
+      # GStreamer versions, use `nvh264enc` instead. If your GPU does not
+      # support CUDA, drop `cudaupload`/`cudaconvert` below (see the
+      # ENCODE-ONLY pipeline further down for that variant).
+      NEKO_CAPTURE_VIDEO_PIPELINE: |
+        ximagesrc display-name={display} show-pointer=true use-damage=false
+          ! video/x-raw,framerate=25/1
+          ! cudaupload ! cudaconvert ! queue
+          ! video/x-raw(memory:CUDAMemory),format=NV12
+          ! nvautogpuh264enc
+            name=encoder
+            preset=2
+            gop-size=25
+            spatial-aq=true
+            temporal-aq=true
+            bitrate=4096
+            vbv-buffer-size=4096
+            rc-mode=6
+          ! h264parse config-interval=-1
+          ! video/x-h264,stream-format=byte-stream
+          ! appsink name=appsink
+      # ENCODE-ONLY OPTION: replace the active pipeline above with this one
+      # when using the plain "firefox" image - it swaps cudaupload/cudaconvert
+      # for a plain videoconvert, since the browser itself no longer needs CUDA:
+      # NEKO_CAPTURE_VIDEO_PIPELINE: |
+      #   ximagesrc display-name={display} show-pointer=true use-damage=false
+      #     ! video/x-raw,framerate=25/1
+      #     ! videoconvert ! queue
+      #     ! video/x-raw,format=NV12
+      #     ! nvautogpuh264enc
+      #       name=encoder
+      #       preset=2
+      #       gop-size=25
+      #       spatial-aq=true
+      #       temporal-aq=true
+      #       bitrate=4096
+      #       vbv-buffer-size=4096
+      #       rc-mode=6
+      #     ! h264parse config-interval=-1
+      #     ! video/x-h264,stream-format=byte-stream
+      #     ! appsink name=appsink
+      NEKO_CAPTURE_VIDEO_CODEC: "h264"
+      NEKO_DESKTOP_SCREEN: 1920x1080@30
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
+      # NEKO_WEBRTC_NAT1TO1: <your-IP>
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu]

--- a/examples/raspberry-pi-browser/docker-compose.yaml
+++ b/examples/raspberry-pi-browser/docker-compose.yaml
@@ -1,0 +1,43 @@
+# Neko - Raspberry Pi Browser Example
+#
+# Runs Firefox on a Raspberry Pi (or similar ARM SBC). Works out of the box
+# with software rendering/encoding; see below for optional hardware-
+# accelerated encoding on boards with a V4L2 M2M encoder (e.g. Pi 3/4).
+#
+# See supported architectures and known caveats:
+# https://neko.m1k1o.net/docs/v3/installation/docker-images#availability
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    # increase on Pi's with more than 1gb ram.
+    shm_size: "520mb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    # note: required for the GPU ACCELERATION OPTION below, alternatively
+    #       mount the specific /dev/video* devices instead of running privileged.
+    # privileged: true
+    environment:
+      # GPU ACCELERATION OPTION: enable hardware encoding via the Broadcom
+      # VideoCore V4L2 M2M encoder (available on Raspberry Pi 3/4, not Pi 5).
+      # Requires `privileged: true` above (or the matching /dev/video* devices).
+      # NEKO_CAPTURE_VIDEO_PIPELINE: |
+      #   ximagesrc display-name={display} show-pointer=true use-damage=false
+      #     ! video/x-raw,framerate=25/1
+      #     ! videoconvert ! queue
+      #     ! video/x-raw,format=NV12
+      #     ! v4l2h264enc
+      #       name=encoder
+      #       extra-controls="controls,h264_profile=1,video_bitrate=1250000;"
+      #     ! h264parse config-interval=-1
+      #     ! video/x-h264,stream-format=byte-stream
+      #     ! appsink name=appsink
+      # NEKO_CAPTURE_VIDEO_CODEC: "h264"
+      NEKO_DESKTOP_SCREEN: '1280x720@30'
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
+      # NEKO_WEBRTC_NAT1TO1: <your-IP>

--- a/examples/simple-browser/docker-compose.yaml
+++ b/examples/simple-browser/docker-compose.yaml
@@ -1,0 +1,39 @@
+# Neko - Simple Browser Example
+#
+# Runs Firefox in Neko. Firefox is the default, most tested image, but Neko
+# supports many other browsers and applications - see the full list here:
+# https://neko.m1k1o.net/docs/v3/installation/docker-images#apps
+#
+# Other browser images you can swap in below:
+#   ghcr.io/m1k1o/neko/chromium
+#   ghcr.io/m1k1o/neko/google-chrome
+#   ghcr.io/m1k1o/neko/brave
+#   ghcr.io/m1k1o/neko/vivaldi
+#   ghcr.io/m1k1o/neko/microsoft-edge
+#   ghcr.io/m1k1o/neko/tor-browser
+#   ghcr.io/m1k1o/neko/waterfox
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    shm_size: "2gb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    # volumes:
+      # Persist Firefox settings, bookmarks, extensions and history across
+      # container restarts by mounting the profile directory.
+      # See: https://neko.m1k1o.net/docs/v3/customization/browsers#persistent-profile
+      # - "./profile:/home/neko/.mozilla/firefox/profile.default"
+
+      # Or mount your own pre-configured Firefox profile instead of an empty one.
+      # See: https://neko.m1k1o.net/docs/v3/customization/browsers#persistent-profile
+      # - "./my-custom-profile:/home/neko/.mozilla/firefox/profile.default"
+    environment:
+      NEKO_DESKTOP_SCREEN: '1920x1080@30'
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
+      # NEKO_WEBRTC_NAT1TO1: <your-IP>

--- a/examples/turn-server/docker-compose.yaml
+++ b/examples/turn-server/docker-compose.yaml
@@ -1,0 +1,52 @@
+# Neko - TURN Server Example
+#
+# WebRTC needs a direct connection between the client and the server. When
+# that is not possible (e.g. both sides are behind restrictive NATs or
+# firewalls), a TURN server relays the traffic instead. This example runs a
+# Coturn TURN server alongside Neko.
+#
+# See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#iceservers
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/firefox:latest"
+    restart: "unless-stopped"
+    shm_size: "2gb"
+    ports:
+      - "8080:8080"
+      - "52000-52100:52000-52100/udp"
+    environment:
+      NEKO_DESKTOP_SCREEN: '1920x1080@30'
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
+      NEKO_WEBRTC_EPR: 52000-52100
+      NEKO_WEBRTC_ICELITE: 1
+      # Tell the client to use the TURN server below as a fallback ICE
+      # server. Replace <MY-COTURN-SERVER> with the LAN or public IP address
+      # the TURN server is reachable at, matching the coturn service below.
+      # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#iceservers
+      NEKO_WEBRTC_ICESERVERS_FRONTEND: |
+        [{
+          "urls": [ "turn:<MY-COTURN-SERVER>:3478" ],
+          "username": "neko",
+          "credential": "neko"
+        }]
+
+  coturn:
+    image: "coturn/coturn:latest"
+    restart: "unless-stopped"
+    network_mode: "host"
+    command: |
+      -n
+      --realm=localhost
+      --fingerprint
+      --listening-ip=0.0.0.0
+      --external-ip=<MY-COTURN-SERVER>
+      --listening-port=3478
+      --min-port=49160
+      --max-port=49200
+      --log-file=stdout
+      --user=neko:neko
+      --lt-cred-mech
+    # Replace <MY-COTURN-SERVER> above with your LAN or Public IP address.
+    # Open ports 3478/tcp (control) and 49160-49200/udp (relay) on your
+    # firewall. More info: https://github.com/coturn/coturn

--- a/webpage/docs/installation/docker-images.md
+++ b/webpage/docs/installation/docker-images.md
@@ -252,7 +252,7 @@ For images with Nvidia GPU hardware acceleration using EGL use:
 - [`ghcr.io/m1k1o/neko/nvidia-microsoft-edge`](https://ghcr.io/m1k1o/neko/nvidia-microsoft-edge)
 - [`ghcr.io/m1k1o/neko/nvidia-brave`](https://ghcr.io/m1k1o/neko/nvidia-brave)
 
-The base image is available at [`ghcr.io/m1k1o/neko/nvidia-base`](https://ghcr.io/m1k1o/neko/nvidia-base). See [Examples](/docs/v3/installation/examples#nvidia) for more information and usage.
+The base image is available at [`ghcr.io/m1k1o/neko/nvidia-base`](https://ghcr.io/m1k1o/neko/nvidia-base). See [Examples](/docs/v3/installation/examples#nvidia-browser) for more information and usage.
 
 ## Supported Architectures {#arch}
 

--- a/webpage/docs/installation/examples.md
+++ b/webpage/docs/installation/examples.md
@@ -6,212 +6,92 @@ description: Example Docker Compose configurations for Neko.
 
 Here are some examples to get you started with Neko. You can use these examples as a reference to create your own configurations.
 
-## Firefox {#firefox}
+Every example below is also available as a self-contained, runnable folder in the [`examples/`](https://github.com/m1k1o/neko/tree/main/examples) directory of the repository, so you can browse, clone or download it directly. Each file is heavily commented, showing the available options and linking to the relevant documentation inline.
 
-```yaml title="docker-compose.yaml"
-services:
-  neko:
-    image: "ghcr.io/m1k1o/neko/firefox:latest"
-    restart: "unless-stopped"
-    shm_size: "2gb"
-    ports:
-      - "8080:8080"
-      - "52000-52100:52000-52100/udp"
-    volumes:
-      - <your-host-path>:/home/neko/.mozilla/firefox # persist firexfox settings
-    environment:
-      NEKO_DESKTOP_SCREEN: '1920x1080@30'
-      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
-      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
-      NEKO_WEBRTC_EPR: 52000-52100
-      NEKO_WEBRTC_ICELITE: 1
-      NEKO_WEBRTC_NAT1TO1: <your-IP>
+## Simple Browser {#simple-browser}
+
+A basic Firefox setup. Includes commented volume mounts for persisting the browser profile or mounting your own pre-configured one, and a list of other browser images you can swap in.
+
+Browse: [`examples/simple-browser`](https://github.com/m1k1o/neko/tree/main/examples/simple-browser)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/simple-browser/docker-compose.yaml
 ```
 
-## Chromium {#chromium}
+See also: [Persistent Browser Profile](/docs/v3/customization/browsers#persistent-profile) and [Browser Policy Files](/docs/v3/customization/browsers#policy-files).
 
-```yaml title="docker-compose.yaml"
-services:
-  neko:
-    image: "ghcr.io/m1k1o/neko/chromium:latest"
-    restart: "unless-stopped"
-    shm_size: "2gb"
-    ports:
-      - "8080:8080"
-      - "52000-52100:52000-52100/udp"
-    volumes:
-      - <your-host-path>:/home/neko/.config/chromium # persist chromium settings
-    environment:
-      NEKO_DESKTOP_SCREEN: '1920x1080@30'
-      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
-      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
-      NEKO_WEBRTC_EPR: 52000-52100
-      NEKO_WEBRTC_ICELITE: 1
-      NEKO_WEBRTC_NAT1TO1: <your-IP>
+## Kiosk Browser {#kiosk-browser}
+
+Runs Firefox in kiosk mode (no address bar, tabs or browser chrome) and opens a fixed URL automatically on startup. This is useful for app-like setups such as streaming services or dashboards, and works by mounting a persistent copy of the Firefox supervisor config and overriding the command directly.
+
+This setup is intentionally stateless - no browser profile is persisted, so logins are lost on every restart. See the comments in the example for how to add a persistent profile if you need to stay logged in.
+
+Browse: [`examples/kiosk-browser`](https://github.com/m1k1o/neko/tree/main/examples/kiosk-browser)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/kiosk-browser/docker-compose.yaml
 ```
 
-## VLC {#vlc}
-
-```yaml title="docker-compose.yaml"
-services:
-  neko:
-    image: "ghcr.io/m1k1o/neko/vlc:latest"
-    restart: "unless-stopped"
-    shm_size: "2gb"
-    volumes:
-      - "<your-video-folder>:/video" # mount your video folder
-    ports:
-      - "8080:8080"
-      - "52000-52100:52000-52100/udp"
-    environment:
-      NEKO_DESKTOP_SCREEN: '1920x1080@30'
-      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
-      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
-      NEKO_WEBRTC_EPR: 52000-52100
-      NEKO_WEBRTC_ICELITE: 1
-      NEKO_WEBRTC_NAT1TO1: <your-IP>
+```ini title="firefox.conf" file=<rootDir>/examples/kiosk-browser/firefox.conf
 ```
 
-## Raspberry Pi GPU Acceleration {#raspberry-pi}
+For some workflows, passing the target URL directly to Firefox is more reliable than using homepage policies, because session restore can otherwise override the start page. See also: [Supervisord Configuration](/docs/v3/customization#supervisord).
 
-```yaml title="docker-compose.yaml"
-services:
-  neko:
-    image: "ghcr.io/m1k1o/neko/chromium:latest"
-    restart: "unless-stopped"
-    # increase on rpi's with more then 1gb ram.
-    shm_size: "520mb"
-    ports:
-      - "8088:8080"
-      - "52000-52100:52000-52100/udp"
-    # note: this is important since we need a GPU for hardware acceleration alternatively
-    #       mount the devices into the docker.
-    privileged: true
-    environment:
-      NEKO_CAPTURE_VIDEO_PIPELINE: |
-        ximagesrc display-name={display} show-pointer=true use-damage=false
-          ! video/x-raw,framerate=25/1
-          ! videoconvert ! queue
-          ! video/x-raw,format=NV12
-          ! v4l2h264enc
-            name=encoder
-            extra-controls="controls,h264_profile=1,video_bitrate=1250000;"
-          ! h264parse config-interval=-1
-          ! video/x-h264,stream-format=byte-stream
-          ! appsink name=appsink
-      NEKO_CAPTURE_VIDEO_CODEC: "h264"
-      NEKO_DESKTOP_SCREEN: '1280x720@30'
-      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
-      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
-      NEKO_WEBRTC_EPR: 52000-52100
-      NEKO_WEBRTC_ICELITE: 1
-```
-
-## Nvidia GPU Acceleration {#nvidia}
+## Nvidia Browser {#nvidia-browser}
 
 Neko supports hardware acceleration using Nvidia GPUs. To use this feature, you need to have the Nvidia Container Toolkit installed on your system. You can find the installation instructions [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html). Check if your GPU supports hardware encoding with [this list](https://developer.nvidia.com/video-encode-decode-gpu-support-matrix).
 
-This example shows how to accelerate video encoding and as well the browser rendering using the GPU. You can test if the GPU is used by running `nvtop` or `nvidia-smi`, which should show the GPU usage of both the browser and neko. In the browser, you can run the [WebGL Aquarium Demo](https://webglsamples.org/aquarium/aquarium.html) to test the GPU usage.
+This example accelerates both video encoding and browser rendering using the GPU. You can test if the GPU is used by running `nvtop` or `nvidia-smi`, which should show the GPU usage of both the browser and neko. In the browser, you can run the [WebGL Aquarium Demo](https://webglsamples.org/aquarium/aquarium.html) to test the GPU usage.
 
-```yaml title="docker-compose.yaml"
-services:
-  neko:
-    image: "ghcr.io/m1k1o/neko/nvidia-firefox:latest"
-    restart: "unless-stopped"
-    shm_size: "2gb"
-    ports:
-      - "8080:8080"
-      - "52000-52100:52000-52100/udp"
-    environment:
-      NEKO_CAPTURE_VIDEO_PIPELINE: |
-        ximagesrc display-name={display} show-pointer=true use-damage=false
-          ! video/x-raw,framerate=25/1
-          ! cudaupload ! cudaconvert ! queue
-          ! video/x-raw(memory:CUDAMemory),format=NV12
-          ! nvautogpuh264enc
-            name=encoder
-            preset=2
-            gop-size=25
-            spatial-aq=true
-            temporal-aq=true
-            bitrate=4096
-            vbv-buffer-size=4096
-            rc-mode=6
-          ! h264parse config-interval=-1
-          ! video/x-h264,stream-format=byte-stream
-          ! appsink name=appsink
-      NEKO_CAPTURE_VIDEO_CODEC: "h264"
-      NEKO_DESKTOP_SCREEN: 1920x1080@30
-      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
-      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
-      NEKO_WEBRTC_EPR: 52000-52100
-      NEKO_WEBRTC_ICELITE: 1
-    deploy:
-      resources:
-        reservations:
-          devices:
-          - driver: nvidia
-            count: 1
-            capabilities: [gpu]
+If you only want to accelerate the encoding, **not the browser rendering**, see the commented "ENCODE-ONLY OPTION" blocks in the example - they switch to the plain `firefox` image and a `videoconvert`-based pipeline instead of `nvidia-firefox` with `cudaupload`/`cudaconvert`.
+
+Browse: [`examples/nvidia-browser`](https://github.com/m1k1o/neko/tree/main/examples/nvidia-browser)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/nvidia-browser/docker-compose.yaml
 ```
 
 See available [Nvidia Docker Images](/docs/v3/installation/docker-images#nvidia).
 
-:::tip
-`nvautogpuh264enc` (GStreamer 1.22+) is the recommended encoder for NVIDIA driver 590 and newer. It automatically selects the correct memory path (CUDA or system) and replaces `nvh264enc`. If you are on an older driver or GStreamer version, substitute `nvautogpuh264enc` with `nvh264enc`.
-:::
+## Intel Browser {#intel-browser}
 
-:::note
-If your Nvidia GPU does not support CUDA, you can use the pipeline below without `cudaupload` and `cudaconvert`. This should work with older GPUs, but the performance might be lower.
-:::
+Neko supports hardware acceleration using Intel GPUs via VAAPI. This requires the host to expose `/dev/dri` and have the Intel graphics driver installed.
 
-If you only want to accelerate the encoding, **not the browser rendering**, and you do not need [Cuda library](https://gstreamer.freedesktop.org/documentation/cuda/index.html?gi-language=c), you can use the default image with additional environment variables:
+This example accelerates both video encoding and browser rendering using the `intel-firefox` image. If you only want to accelerate the encoding, **not the browser rendering**, see the commented "ENCODE-ONLY OPTION" in the example, which switches to the plain `firefox` image.
 
-```yaml title="docker-compose.yaml"
-services:
-  neko:
-    # highlight-next-line
-    image: "ghcr.io/m1k1o/neko/firefox:latest"
-    restart: "unless-stopped"
-    shm_size: "2gb"
-    ports:
-      - "8080:8080"
-      - "52000-52100:52000-52100/udp"
-    environment:
-      # highlight-start
-      NVIDIA_VISIBLE_DEVICES: all
-      NVIDIA_DRIVER_CAPABILITIES: all
-      # highlight-end
-      NEKO_CAPTURE_VIDEO_PIPELINE: |
-        ximagesrc display-name={display} show-pointer=true use-damage=false
-          ! video/x-raw,framerate=25/1
-      # highlight-start
-          ! videoconvert ! queue
-          ! video/x-raw,format=NV12
-      # highlight-end
-          ! nvautogpuh264enc
-            name=encoder
-            preset=2
-            gop-size=25
-            spatial-aq=true
-            temporal-aq=true
-            bitrate=4096
-            vbv-buffer-size=4096
-            rc-mode=6
-          ! h264parse config-interval=-1
-          ! video/x-h264,stream-format=byte-stream
-          ! appsink name=appsink
-      NEKO_CAPTURE_VIDEO_CODEC: "h264"
-      NEKO_DESKTOP_SCREEN: 1920x1080@30
-      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: neko
-      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: admin
-      NEKO_WEBRTC_EPR: 52000-52100
-      NEKO_WEBRTC_ICELITE: 1
-    deploy:
-      resources:
-        reservations:
-          devices:
-          - driver: nvidia
-            count: 1
-            capabilities: [gpu]
+Browse: [`examples/intel-browser`](https://github.com/m1k1o/neko/tree/main/examples/intel-browser)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/intel-browser/docker-compose.yaml
 ```
+
+See available [Intel Docker Images](/docs/v3/installation/docker-images#intel).
+
+## Raspberry Pi Browser {#raspberry-pi-browser}
+
+Firefox tuned for a Raspberry Pi (or similar ARM SBC). Works out of the box with software rendering/encoding. See the commented "GPU ACCELERATION OPTION" in the example for enabling hardware-accelerated encoding via the Broadcom VideoCore V4L2 M2M encoder, available on Raspberry Pi 3/4 (not Pi 5).
+
+Browse: [`examples/raspberry-pi-browser`](https://github.com/m1k1o/neko/tree/main/examples/raspberry-pi-browser)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/raspberry-pi-browser/docker-compose.yaml
+```
+
+## ARM64 Browser {#arm64-browser}
+
+Firefox on a generic ARM64 host (e.g. Apple M1/M2 under virtualization, AWS Graviton, Oracle Cloud ARM free tier). The same multi-arch image used on amd64 works here - no special image tag is required.
+
+DRM (Widevine) support is limited on ARM64 and needs extra setup for protected streaming content, see [DRM for ARM64](/docs/v3/customization/browsers#arm64-drm). If your device exposes a V4L2 M2M hardware encoder, you can reuse the pipeline from the [Raspberry Pi Browser](#raspberry-pi-browser) example.
+
+Browse: [`examples/arm64-browser`](https://github.com/m1k1o/neko/tree/main/examples/arm64-browser)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/arm64-browser/docker-compose.yaml
+```
+
+See supported architectures and per-app availability in the [Availability Matrix](/docs/v3/installation/docker-images#availability).
+
+## TURN Server {#turn-server}
+
+WebRTC needs a direct connection between the client and the server. When that is not possible (e.g. both sides are behind restrictive NATs or firewalls), a [TURN server](/docs/v3/configuration/webrtc#iceservers) relays the traffic instead. This example runs a [Coturn](https://github.com/coturn/coturn) TURN server alongside Neko.
+
+Browse: [`examples/turn-server`](https://github.com/m1k1o/neko/tree/main/examples/turn-server)
+
+```yaml title="docker-compose.yaml" file=<rootDir>/examples/turn-server/docker-compose.yaml
+```
+
+Replace `<MY-COTURN-SERVER>` with your LAN or Public IP address, and allow ports `49160-49200/udp` and `3478/tcp`.

--- a/webpage/docusaurus.config.ts
+++ b/webpage/docusaurus.config.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
@@ -6,196 +7,203 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
-const config: Config = {
-  title: 'n.eko',
-  tagline: 'A self hosted virtual browser that runs in docker and uses WebRTC.',
-  favicon: 'img/favicon.ico',
+// remark-code-import is ESM-only, so it must be loaded via dynamic import.
+export default async function createConfig(): Promise<Config> {
+  const {default: codeImport} = await import('remark-code-import');
 
-  // Set the production url of your site here
-  url: 'https://neko.m1k1o.net',
-  // Set the /<baseUrl>/ pathname under which your site is served
-  // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  const config: Config = {
+    title: 'n.eko',
+    tagline: 'A self hosted virtual browser that runs in docker and uses WebRTC.',
+    favicon: 'img/favicon.ico',
 
-  // GitHub pages deployment config.
-  organizationName: 'm1k1o',
-  projectName: 'neko',
-  trailingSlash: false,
+    // Set the production url of your site here
+    url: 'https://neko.m1k1o.net',
+    // Set the /<baseUrl>/ pathname under which your site is served
+    // For GitHub pages deployment, it is often '/<projectName>/'
+    baseUrl: '/',
 
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+    // GitHub pages deployment config.
+    organizationName: 'm1k1o',
+    projectName: 'neko',
+    trailingSlash: false,
 
-  i18n: {
-    defaultLocale: 'en',
-    locales: ['en'],
-  },
+    onBrokenLinks: 'throw',
+    onBrokenMarkdownLinks: 'warn',
 
-  presets: [
-    [
-      'classic',
-      {
-        docs: {
-          sidebarPath: './sidebars.ts',
-          docItemComponent: "@theme/ApiItem", // Derived from docusaurus-theme-openapi
-          editUrl: 'https://github.com/m1k1o/neko/tree/main/webpage/',
-          lastVersion: 'current',
-          versions: {
-            current: {
-              label: 'v3',
-              path: 'v3',
+    i18n: {
+      defaultLocale: 'en',
+      locales: ['en'],
+    },
+
+    presets: [
+      [
+        'classic',
+        {
+          docs: {
+            sidebarPath: './sidebars.ts',
+            docItemComponent: "@theme/ApiItem", // Derived from docusaurus-theme-openapi
+            editUrl: 'https://github.com/m1k1o/neko/tree/main/webpage/',
+            lastVersion: 'current',
+            versions: {
+              current: {
+                label: 'v3',
+                path: 'v3',
+              },
             },
+            // Allows embedding files from the repo-level `examples/` folder into docs via ```yaml file=examples/foo/docker-compose.yaml```
+            remarkPlugins: [[codeImport, {rootDir: path.resolve(__dirname, '..')}]],
           },
-        },
-        //blog: {
-        //  showReadingTime: true,
-        //  feedOptions: {
-        //    type: ['rss', 'atom'],
-        //    xslt: true,
-        //  },
-        //  editUrl: 'https://github.com/m1k1o/neko/tree/main/docs/',
-        //  // Useful options to enforce blogging best practices
-        //  onInlineTags: 'warn',
-        //  onInlineAuthors: 'warn',
-        //  onUntruncatedBlogPosts: 'warn',
-        //},
-        theme: {
-          customCss: './src/css/custom.css',
-        },
-      } satisfies Preset.Options,
+          //blog: {
+          //  showReadingTime: true,
+          //  feedOptions: {
+          //    type: ['rss', 'atom'],
+          //    xslt: true,
+          //  },
+          //  editUrl: 'https://github.com/m1k1o/neko/tree/main/docs/',
+          //  // Useful options to enforce blogging best practices
+          //  onInlineTags: 'warn',
+          //  onInlineAuthors: 'warn',
+          //  onUntruncatedBlogPosts: 'warn',
+          //},
+          theme: {
+            customCss: './src/css/custom.css',
+          },
+        } satisfies Preset.Options,
+      ],
     ],
-  ],
 
-  themeConfig: {
-    image: 'img/neko-social-card.jpg',
-    navbar: {
-      //title: 'n.eko',
-      logo: {
-        alt: 'n.eko',
-        src: 'img/logo.png',
+    themeConfig: {
+      image: 'img/neko-social-card.jpg',
+      navbar: {
+        //title: 'n.eko',
+        logo: {
+          alt: 'n.eko',
+          src: 'img/logo.png',
+        },
+        items: [
+          {
+            type: 'docSidebar',
+            sidebarId: 'docsSidebar',
+            position: 'left',
+            label: 'Docs',
+          },
+          {
+            to: 'contributing',
+            label: 'Contributing',
+            position: 'left',
+          },
+          {
+            to: 'non-goals',
+            label: 'Non-Goals',
+            position: 'left',
+          },
+          {
+            to: 'contact',
+            label: 'Contact',
+            position: 'left',
+          },
+          {
+            href: 'https://github.com/sponsors/m1k1o',
+            label: 'Donate',
+            position: 'left',
+          },
+          {
+            type: 'docsVersionDropdown',
+            position: 'right',
+          },
+          {
+            href: 'https://discord.gg/HXQJmqNJMz',
+            label: 'Discord',
+            position: 'right',
+          },
+          {
+            href: 'https://github.com/m1k1o/neko',
+            label: 'GitHub',
+            position: 'right',
+          },
+        ],
       },
-      items: [
+      footer: {
+        style: 'dark',
+        links: [
+          {
+            title: 'Other Projects',
+            items: [
+              {
+                label: 'Neko Rooms',
+                href: 'https://github.com/m1k1o/neko-rooms',
+              },
+              {
+                label: 'Neko Apps',
+                href: 'https://github.com/m1k1o/neko-apps',
+              },
+              {
+                label: 'Neko VPN',
+                href: 'https://github.com/m1k1o/neko-vpn',
+              },
+            ],
+          },
+          {
+            title: 'Community',
+            items: [
+              {
+                label: 'Discord',
+                href: 'https://discord.gg/HXQJmqNJMz',
+              },
+              {
+                label: 'Issues',
+                href: 'https://github.com/m1k1o/neko/issues',
+              },
+            ],
+          },
+          {
+            title: 'More',
+            items: [
+              {
+                label: 'GitHub',
+                href: 'https://github.com/m1k1o/neko',
+              },
+              {
+                label: 'Sponsors',
+                href: 'https://github.com/sponsors/m1k1o',
+              },
+            ],
+          },
+        ],
+        copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/m1k1o">m1k1o</a>. Built with Docusaurus.`,
+      },
+      prism: {
+        theme: prismThemes.github,
+        darkTheme: prismThemes.dracula,
+        additionalLanguages: ['bash'],
+      },
+    } satisfies Preset.ThemeConfig,
+
+    plugins: [
+      [
+        "docusaurus-plugin-openapi-docs",
         {
-          type: 'docSidebar',
-          sidebarId: 'docsSidebar',
-          position: 'left',
-          label: 'Docs',
-        },
-        {
-          to: 'contributing',
-          label: 'Contributing',
-          position: 'left',
-        },
-        {
-          to: 'non-goals',
-          label: 'Non-Goals',
-          position: 'left',
-        },
-        {
-          to: 'contact',
-          label: 'Contact',
-          position: 'left',
-        },
-        {
-          href: 'https://github.com/sponsors/m1k1o',
-          label: 'Donate',
-          position: 'left',
-        },
-        {
-          type: 'docsVersionDropdown',
-          position: 'right',
-        },
-        {
-          href: 'https://discord.gg/HXQJmqNJMz',
-          label: 'Discord',
-          position: 'right',
-        },
-        {
-          href: 'https://github.com/m1k1o/neko',
-          label: 'GitHub',
-          position: 'right',
+          id: "openapi",
+          docsPluginId: "classic",
+          config: {
+            api: {
+              specPath: "../server/openapi.yaml",
+              outputDir: "docs/api",
+              downloadUrl: "https://raw.githubusercontent.com/m1k1o/neko/refs/heads/master/server/openapi.yaml",
+              baseUrl: "/docs/v3/api",
+              sidebarOptions: {
+                groupPathsBy: "tag",
+                categoryLinkSource: "tag",
+                sidebarCollapsed: false,
+              },
+            } satisfies OpenApiPlugin.Options,
+          } satisfies Plugin.PluginOptions,
         },
       ],
-    },
-    footer: {
-      style: 'dark',
-      links: [
-        {
-          title: 'Other Projects',
-          items: [
-            {
-              label: 'Neko Rooms',
-              href: 'https://github.com/m1k1o/neko-rooms',
-            },
-            {
-              label: 'Neko Apps',
-              href: 'https://github.com/m1k1o/neko-apps',
-            },
-            {
-              label: 'Neko VPN',
-              href: 'https://github.com/m1k1o/neko-vpn',
-            },
-          ],
-        },
-        {
-          title: 'Community',
-          items: [
-            {
-              label: 'Discord',
-              href: 'https://discord.gg/HXQJmqNJMz',
-            },
-            {
-              label: 'Issues',
-              href: 'https://github.com/m1k1o/neko/issues',
-            },
-          ],
-        },
-        {
-          title: 'More',
-          items: [
-            {
-              label: 'GitHub',
-              href: 'https://github.com/m1k1o/neko',
-            },
-            {
-              label: 'Sponsors',
-              href: 'https://github.com/sponsors/m1k1o',
-            },
-          ],
-        },
-      ],
-      copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/m1k1o">m1k1o</a>. Built with Docusaurus.`,
-    },
-    prism: {
-      theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
-      additionalLanguages: ['bash'],
-    },
-  } satisfies Preset.ThemeConfig,
-
-  plugins: [
-    [
-      "docusaurus-plugin-openapi-docs",
-      {
-        id: "openapi",
-        docsPluginId: "classic",
-        config: {
-          api: {
-            specPath: "../server/openapi.yaml",
-            outputDir: "docs/api",
-            downloadUrl: "https://raw.githubusercontent.com/m1k1o/neko/refs/heads/master/server/openapi.yaml",
-            baseUrl: "/docs/v3/api",
-            sidebarOptions: {
-              groupPathsBy: "tag",
-              categoryLinkSource: "tag",
-              sidebarCollapsed: false,
-            },
-          } satisfies OpenApiPlugin.Options,
-        } satisfies Plugin.PluginOptions,
-      },
     ],
-  ],
 
-  themes: ["docusaurus-theme-openapi-docs"],
-};
+    themes: ["docusaurus-theme-openapi-docs"],
+  };
 
-export default config;
+  return config;
+}

--- a/webpage/package-lock.json
+++ b/webpage/package-lock.json
@@ -16,7 +16,8 @@
         "docusaurus-theme-openapi-docs": "^4.3.4",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "remark-code-import": "^1.2.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.7.0",
@@ -19250,6 +19251,68 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-code-import": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remark-code-import/-/remark-code-import-1.2.0.tgz",
+      "integrity": "sha512-fgwLruqlZbVOIhCJFjY+JDwPZhA4/eK3InJzN8Ox8UDdtudpG212JwtRj6la+lAzJU7JmSEyewZSukVZdknt3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "strip-indent": "^4.0.0",
+        "to-gatsby-remark-plugin": "^0.1.0",
+        "unist-util-visit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/remark-code-import/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/remark-code-import/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-code-import/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-code-import/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-directive": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
@@ -20711,6 +20774,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -21067,6 +21142,15 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/to-gatsby-remark-plugin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/to-gatsby-remark-plugin/-/to-gatsby-remark-plugin-0.1.0.tgz",
+      "integrity": "sha512-blmhJ/gIrytWnWLgPSRCkhCPeki6UBK2daa3k9mGahN7GjwHu8KrS7F70MvwlsG7IE794JLgwAdCbi4hU4faFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "to-vfile": "^6.1.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -21077,6 +21161,69 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-vfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-6.1.0.tgz",
+      "integrity": "sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/to-vfile/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/to-vfile/node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/to-vfile/node_modules/vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/to-vfile/node_modules/vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/toidentifier": {

--- a/webpage/package.json
+++ b/webpage/package.json
@@ -26,7 +26,8 @@
     "docusaurus-theme-openapi-docs": "^4.3.4",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "remark-code-import": "^1.2.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0",


### PR DESCRIPTION
- Introduced a simple browser example using Firefox in Docker with optional persistent profile configuration.
- Added a TURN server example using Coturn alongside Neko for WebRTC support.
- Updated installation documentation to include new examples and improved organization.
- Enhanced Docusaurus configuration to support dynamic code imports for example files.
- Updated package dependencies to include remark-code-import for better documentation handling.