### PR TITLE
feat: add ARM64 Google Chrome image

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -36,7 +36,7 @@ jobs:
           - name: chromium
             platforms: linux/amd64,linux/arm64
           - name: google-chrome
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
           - name: ungoogled-chromium
             platforms: linux/amd64
           - name: microsoft-edge

--- a/apps/google-chrome/Dockerfile
+++ b/apps/google-chrome/Dockerfile
@@ -1,13 +1,27 @@
 ARG BASE_IMAGE=ghcr.io/m1k1o/neko/base:latest
 FROM $BASE_IMAGE
 
-ARG SRC_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+# Set this to a complete .deb URL to pin a specific Chrome version. By default,
+# download the package matching the image architecture.
+ARG SRC_URL=""
 
 #
 # install google chrome
-RUN set -eux; apt-get update; \
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+        amd64|arm64) ;; \
+        *) echo "Google Chrome is not available for ${ARCH}" >&2; exit 1 ;; \
+    esac; \
+    SRC_URL="${SRC_URL:-https://dl.google.com/linux/direct/google-chrome-stable_current_${ARCH}.deb}"; \
+    apt-get update; \
     wget -O /tmp/google-chrome.deb "${SRC_URL}"; \
     apt-get install -y --no-install-recommends openbox /tmp/google-chrome.deb; \
+    # Install the ARM64 CDM prepared by the runtime where Chrome discovers it.
+    if [ "${ARCH}" = "arm64" ]; then \
+        mkdir -p /opt/google/chrome/WidevineCdm; \
+        find /var/lib/widevine/WidevineCdm/ ! -name "WidevineCdm" -exec cp -RL {} /opt/google/chrome/WidevineCdm/ \; ; \
+    fi; \
     #
     # clean up
     apt-get clean -y; \

--- a/webpage/docs/installation/docker-images.md
+++ b/webpage/docs/installation/docker-images.md
@@ -271,7 +271,7 @@ The availability of applications for ARM architecture is limited due to the lack
 | [Tor Browser](#tor-browser)               | ✅    | ❌    | [Forum Post](https://forum.torproject.org/t/tor-browser-for-arm-linux/5240) |
 | [Waterfox](#waterfox)                     | ✅    | ❌    | [Github Issue](https://github.com/BrowserWorks/Waterfox/issues/1506), [Reddit](https://www.reddit.com/r/waterfox/comments/jpqsds/are_there_any_builds_for_arm64/) |
 | [Chromium](#chromium)                     | ✅    | ✅ \* | - |
-| [Google Chrome](#google-chrome)           | ✅    | ❌    | [Community Post](https://askubuntu.com/a/1383791) |
+| [Google Chrome](#google-chrome)           | ✅    | ✅ \* | - |
 | [Ungoogled Chromium](#ungoogled-chromium) | ✅    | ❌    | [Downloads Page](https://ungoogled-software.github.io/ungoogled-chromium-binaries/) |
 | [Microsoft Edge](#microsoft-edge)         | ✅    | ❌    | [Community Post](https://techcommunity.microsoft.com/discussions/edgeinsiderdiscussions/edge-for-linuxarm64/1532272) |
 | [Brave](#brave)                           | ✅    | ✅ \* | - |


### PR DESCRIPTION
## Summary
- install the Google Chrome package matching the target architecture
- publish Google Chrome for linux/arm64
- mark Google Chrome ARM64 support in the image availability matrix

Google announced Chrome for ARM64 Linux devices in Q2 2026: https://blog.google/chromium/bringing-chrome-to-arm64-linux-devices/

## Validation
- `docker buildx build --platform linux/arm64 --call=check apps/google-chrome`
- ARM64 base and Google Chrome branch-image workflow: https://github.com/ybbapp/neko/actions/runs/31498294879