### PR TITLE
feat(capture): toggle mouse pointer via capture.video.show_pointer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,3 +34,4 @@ services:
       # Specifying reachable IP by clients is required when running Neko.
       # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
       NEKO_WEBRTC_NAT1TO1: <your-IP>
+      # NEKO_CAPTURE_VIDEO_SHOW_POINTER: false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,4 +34,3 @@ services:
       # Specifying reachable IP by clients is required when running Neko.
       # See: https://neko.m1k1o.net/docs/v3/configuration/webrtc#nat1to1
       NEKO_WEBRTC_NAT1TO1: <your-IP>
-      # NEKO_CAPTURE_VIDEO_SHOW_POINTER: false

--- a/server/internal/capture/manager.go
+++ b/server/internal/capture/manager.go
@@ -101,12 +101,12 @@ func New(desktop types.DesktopManager, config *config.Capture) *CaptureManagerCt
 					"! queue "+
 					"! voaacenc bitrate=%d "+
 					"! mux. "+
-					"ximagesrc display-name=%s show-pointer=true use-damage=false "+
+					"ximagesrc display-name=%s show-pointer=%v use-damage=false "+
 					"! video/x-raw "+
 					"! videoconvert "+
 					"! queue "+
 					"! x264enc threads=4 bitrate=%d key-int-max=15 byte-stream=true tune=zerolatency speed-preset=%s "+
-					"! mux.", url, config.AudioDevice, config.BroadcastAudioBitrate*1000, config.Display, config.BroadcastVideoBitrate, config.BroadcastPreset,
+					"! mux.", url, config.AudioDevice, config.BroadcastAudioBitrate*1000, config.Display, config.VideoShowPointer, config.BroadcastVideoBitrate, config.BroadcastPreset,
 			), nil
 		}, config.BroadcastUrl, config.BroadcastAutostart),
 		screencast: screencastNew(config.ScreencastEnabled, func() string {
@@ -116,12 +116,12 @@ func New(desktop types.DesktopManager, config *config.Capture) *CaptureManagerCt
 			}
 
 			return fmt.Sprintf(
-				"ximagesrc display-name=%s show-pointer=true use-damage=false "+
+				"ximagesrc display-name=%s show-pointer=%v use-damage=false "+
 					"! video/x-raw,framerate=%s "+
 					"! videoconvert "+
 					"! queue "+
 					"! jpegenc quality=%s "+
-					"! appsink name=appsink", config.Display, config.ScreencastRate, config.ScreencastQuality,
+					"! appsink name=appsink", config.Display, config.VideoShowPointer, config.ScreencastRate, config.ScreencastQuality,
 			)
 		}()),
 

--- a/server/internal/config/capture.go
+++ b/server/internal/config/capture.go
@@ -100,6 +100,11 @@ func (Capture) Init(cmd *cobra.Command) error {
 		return err
 	}
 
+	cmd.PersistentFlags().Bool("capture.video.show_pointer", true, "show mouse pointer in captured video, overrides show_pointer of all video pipelines")
+	if err := viper.BindPFlag("capture.video.show_pointer", cmd.PersistentFlags().Lookup("capture.video.show_pointer")); err != nil {
+		return err
+	}
+
 	// broadcast
 	cmd.PersistentFlags().Int("capture.broadcast.audio_bitrate", 128, "broadcast audio bitrate in KB/s")
 	if err := viper.BindPFlag("capture.broadcast.audio_bitrate", cmd.PersistentFlags().Lookup("capture.broadcast.audio_bitrate")); err != nil {
@@ -369,8 +374,9 @@ func (s *Capture) Set() {
 			s.VideoCodec = codec.VP8()
 			s.VideoPipelines = map[string]types.VideoConfig{
 				"main": {
-					Fps:        "25",
-					GstEncoder: "vp8enc",
+					Fps:         "25",
+					GstEncoder:  "vp8enc",
+					ShowPointer: true,
 					GstParams: map[string]string{
 						"target-bitrate":      "round(3072 * 650)",
 						"cpu-used":            "4",
@@ -398,6 +404,14 @@ func (s *Capture) Set() {
 		}
 	} else if videoPipeline != "" {
 		log.Warn().Msg("you are setting both single video pipeline and multiple video pipelines, ignoring single video pipeline")
+	}
+
+	if viper.IsSet("capture.video.show_pointer") {
+		showPointer := viper.GetBool("capture.video.show_pointer")
+		for k, p := range s.VideoPipelines {
+			p.ShowPointer = showPointer
+			s.VideoPipelines[k] = p
+		}
 	}
 
 	// audio

--- a/server/internal/config/capture.go
+++ b/server/internal/config/capture.go
@@ -28,9 +28,10 @@ const (
 type Capture struct {
 	Display string
 
-	VideoCodec     codec.RTPCodec
-	VideoIDs       []string
-	VideoPipelines map[string]types.VideoConfig
+	VideoCodec       codec.RTPCodec
+	VideoIDs         []string
+	VideoPipelines   map[string]types.VideoConfig
+	VideoShowPointer bool
 
 	AudioDevice   string
 	AudioCodec    codec.RTPCodec
@@ -406,10 +407,10 @@ func (s *Capture) Set() {
 		log.Warn().Msg("you are setting both single video pipeline and multiple video pipelines, ignoring single video pipeline")
 	}
 
+	s.VideoShowPointer = viper.GetBool("capture.video.show_pointer")
 	if viper.IsSet("capture.video.show_pointer") {
-		showPointer := viper.GetBool("capture.video.show_pointer")
 		for k, p := range s.VideoPipelines {
-			p.ShowPointer = showPointer
+			p.ShowPointer = s.VideoShowPointer
 			s.VideoPipelines[k] = p
 		}
 	}

--- a/webpage/docs/configuration/capture.md
+++ b/webpage/docs/configuration/capture.md
@@ -35,6 +35,7 @@ The Gstreamer pipeline is started when the first client requests the video strea
   "capture.video.ids",
   "capture.video.pipeline",
   "capture.video.pipelines",
+  "capture.video.show_pointer",
 ]} comments={false} />
 
 - <Def id="video.display" /> is the name of the [X display](https://www.x.org/wiki/) that you want to capture. If not specified, the environment variable `DISPLAY` will be used.
@@ -42,6 +43,7 @@ The Gstreamer pipeline is started when the first client requests the video strea
 - <Def id="video.ids" /> is a list of pipeline ids that are defined in the <Opt id="video.pipelines" /> section. The first pipeline in the list will be the default pipeline.
 - <Def id="video.pipeline" /> is a shorthand for defining [Gstreamer pipeline description](#video.gst_pipeline) for a single pipeline. This is option is ignored if <Opt id="video.pipelines" /> is defined.
 - <Def id="video.pipelines" /> is a dictionary of pipeline configurations. Each pipeline configuration is defined by a unique pipeline id. They can be defined in two ways: either by building the pipeline dynamically using [Expression-Driven Configuration](#video.expression) or by defining the pipeline using a [Gstreamer Pipeline Description](#video.gst_pipeline).
+- <Def id="video.show_pointer" /> overrides <Opt id="video.pipelines.show_pointer" /> for every video pipeline, only if explicitly set (per-pipeline `show_pointer` in `config.yaml` is left untouched when this flag is unset). It also controls the mouse pointer for the [Broadcast](#broadcast) and [Screencast](#screencast) pipelines, which do not have a per-pipeline setting of their own.
 
 ### Expression-Driven Configuration {#video.expression}
 

--- a/webpage/docs/configuration/help.json
+++ b/webpage/docs/configuration/help.json
@@ -195,6 +195,16 @@
   {
     "key": [
       "capture",
+      "video",
+      "show_pointer"
+    ],
+    "type": "boolean",
+    "defaultValue": "true",
+    "description": "show mouse pointer in captured video, overrides show_pointer of all video pipelines"
+  },
+  {
+    "key": [
+      "capture",
       "webcam",
       "device"
     ],

--- a/webpage/docs/configuration/help.txt
+++ b/webpage/docs/configuration/help.txt
@@ -18,6 +18,7 @@
       --capture.video.ids strings                     ordered list of video ids
       --capture.video.pipeline string                 shortcut for configuring only a single gstreamer pipeline, ignored if pipelines is set
       --capture.video.pipelines string                pipelines config used for video streaming (default "{}")
+      --capture.video.show_pointer                    show mouse pointer in captured video, overrides show_pointer of all video pipelines (default true)
       --capture.webcam.device string                  v4l2sink device used for webcam (default "/dev/video0")
       --capture.webcam.enabled                        enable webcam stream
       --capture.webcam.height int                     webcam stream height (default 720)


### PR DESCRIPTION
- config: register capture.video.show_pointer config option
- config: default pointer to visible (ShowPointer: true) on the
hardcoded fallback pipeline, override applies only when the flag is
explicitly set, so per-pipeline YAML overrides stay untouched
- compose: document NEKO_CAPTURE_VIDEO_SHOW_POINTER example