### PR TITLE
enable automatic video quality for v2 clients

### DIFF
--- a/server/internal/http/legacy/handler.go
+++ b/server/internal/http/legacy/handler.go
@@ -122,9 +122,13 @@ func (h *LegacyHandler) Route(r types.Router) {
 		s.connBackend = connBackend
 
 		// request signal
-		if err = s.toBackend(event.SIGNAL_REQUEST, message.SignalRequest{}); err != nil {
+		videoAuto := true
+		if err = s.toBackend(event.SIGNAL_REQUEST, message.SignalRequest{
+			Video: types.PeerVideoRequest{
+				Auto: &videoAuto,
+			},
+		}); err != nil {
 			h.logger.Error().Err(err).Msg("couldn't request signal")
-
 			s.toClient(&oldMessage.SystemMessage{
 				Event:   oldEvent.SYSTEM_DISCONNECT,
 				Title:   "couldn't request signal",


### PR DESCRIPTION
The legacy (v2) client does not provide a UI for selecting a video pipeline, so automatic video quality selection is the only way it can benefit from multiple pipelines.

Previously, the legacy WebSocket bridge sent an empty `SignalRequest`, leaving `Video.Auto` unset. This caused the peer to be created with `videoAuto=false`, preventing the bandwidth estimator from switching pipelines.

This change explicitly enables automatic video quality selection for legacy clients.

This is a no-op with the default configuration: when only a single video pipeline is configured, there is nothing for the stream selector to switch to. The change only has an effect when the operator configures multiple pipelines and enables the bandwidth estimator.