### PR TITLE
fix(webrtc): stop RTCP PLI goroutine when remote track ends

### DIFF
--- a/server/internal/webrtc/manager.go
+++ b/server/internal/webrtc/manager.go
@@ -443,16 +443,25 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session) (*webrtc.Sess
 		ticker := time.NewTicker(rtcpPLIInterval)
 		defer ticker.Stop()
 
-		go func() {
-			for range ticker.C {
-				err := connection.WriteRTCP([]rtcp.Packet{
-					&rtcp.PictureLossIndication{
-						MediaSSRC: uint32(track.SSRC()),
-					},
-				})
+		//ticker.Stop() does not close channel,so the channel,so the goroutine below needs
+		//its own singal to exit, otherwise it would block on the ticker channel forever and leak memory
+		done := make(chan struct{})
+		defer close(done)
 
-				if err != nil {
-					logger.Err(err).Msg("remote track rtcp send err")
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					err := connection.WriteRTCP([]rtcp.Packet{
+						&rtcp.PictureLossIndication{
+							MediaSSRC: uint32(track.SSRC()),
+						},
+					})
+					if err != nil {
+						logger.Err(err).Msg("remote track rtcp send err")
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
Ran into this reading through the `OnTrack` handler.

The PLI goroutine loops with `for range ticker.C`, but `ticker.Stop()` doesn't close
the channel — so when the handler returns (track ended, peer disconnected, or
`srcManager.Start()` failed), the goroutine just sits there blocked forever, still
holding on to the connection and the track. That's one goroutine per remote track,
so it adds up on a long-running instance where people toggle their mic/cam.

Gave it a `done` channel closed on return and selected on that next to the ticker.
Nothing changes while the track is alive.

I also dropped that log line to warn — a failed RTCP write on a connection that's
going away didn't feel like an error. Happy to revert that bit if you'd rather keep
it as is.

The other two `for range ticker.C` loops in the package (peer.go, metrics.go) already
break on `PeerConnectionStateClosed`, so they end with the connection and I left them
alone.
