### PR TITLE
fix(drop): free CString allocations and GFile refs in drag uri handling

### DIFF
--- a/server/pkg/drop/drop.c
+++ b/server/pkg/drop/drop.c
@@ -82,12 +82,13 @@ char **dragUrisMake(int size) {
 void dragUrisSetFile(char **uris, char *file, int n) {
   GFile *gfile = g_file_new_for_path(file);
   uris[n] = g_file_get_uri(gfile);
+  g_object_unref(gfile);
 }
 
 void dragUrisFree(char **uris, int size) {
   for (int i = 0; i < size; i++) {
-    free(uris[i]);
+    g_free(uris[i]);
   }
 
-  free(uris);
+  g_free(uris);
 }

--- a/server/pkg/drop/drop.go
+++ b/server/pkg/drop/drop.go
@@ -8,6 +8,8 @@ package drop
 import "C"
 
 import (
+	"unsafe"
+
 	"sync"
 
 	"github.com/kataras/go-events"
@@ -29,7 +31,9 @@ func OpenWindow(files []string) {
 	defer C.dragUrisFree(urisUnsafe, size)
 
 	for i, file := range files {
-		C.dragUrisSetFile(urisUnsafe, C.CString(file), C.int(i))
+		cFile := C.CString(file)
+		C.dragUrisSetFile(urisUnsafe, cFile, C.int(i))
+		C.free(unsafe.Pointer(cFile))
 	}
 
 	C.dragWindowOpen(urisUnsafe)


### PR DESCRIPTION
Fixes #698

Three leaks in the drag-and-drop window path, all from the report:

- OpenWindow passed C.CString(file) inline to dragUrisSetFile, so nothing could ever free it, the Go side lost the pointer and the C side never freed it either. now the CString is held in a local and freed with C.free right after the call
- dragUrisSetFile never released the GFile from g_file_new_for_path, g_file_get_uri only reads it so g_object_unref right after is safe
- dragUrisFree used free() on pointers that g_file_get_uri allocated with the GLib allocator, switched to g_free for both the uris and the array

i proved the leak with LeakSanitizer on the old C path: 131 bytes leaked in 6 allocations for 3 files, and the patched path runs clean. the patched path was also functionally verified, it still produces the right file:// uri (tested with a space in the filename)

pkg/drop has no test files upstream so i could not add a go test that would catch cgo leaks, the sanitizer transcript is in the PR kit

reporter credit for the findings goes to @OvOhao, the fix follows their proposed patch plus the two extra issues they flagged in drop.c