### PR TITLE
fix(capture): accept a bare pipeline string in video pipelines entries

### DIFF
--- a/server/internal/config/capture.go
+++ b/server/internal/config/capture.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"os"
+	"reflect"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/pion/webrtc/v4"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -322,6 +324,17 @@ func (Capture) InitV2(cmd *cobra.Command) error {
 	return nil
 }
 
+// videoPipelineShorthandHook accepts a bare pipeline string in place of a full
+// video pipeline config, mirroring the capture.video.pipeline shorthand.
+func videoPipelineShorthandHook() mapstructure.DecodeHookFunc {
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if from.Kind() == reflect.String && to == reflect.TypeOf(types.VideoConfig{}) {
+			return types.VideoConfig{GstPipeline: data.(string)}, nil
+		}
+		return data, nil
+	}
+}
+
 func (s *Capture) Set() {
 	var ok bool
 
@@ -342,7 +355,10 @@ func (s *Capture) Set() {
 
 	s.VideoIDs = viper.GetStringSlice("capture.video.ids")
 	if err := viper.UnmarshalKey("capture.video.pipelines", &s.VideoPipelines, viper.DecodeHook(
-		utils.JsonStringAutoDecode(s.VideoPipelines),
+		mapstructure.ComposeDecodeHookFunc(
+			utils.JsonStringAutoDecode(s.VideoPipelines),
+			videoPipelineShorthandHook(),
+		),
 	)); err != nil {
 		log.Warn().Err(err).Msgf("unable to parse video pipelines")
 	}

--- a/server/internal/config/capture_test.go
+++ b/server/internal/config/capture_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// loadCaptureFromEnv mirrors the production config flow: env prefix setup,
+// flag registration via Init, then value population via Set.
+func loadCaptureFromEnv(t *testing.T, pipelines string) *Capture {
+	t.Helper()
+
+	viper.Reset()
+	viper.SetEnvPrefix("NEKO")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+
+	t.Setenv("NEKO_CAPTURE_VIDEO_PIPELINES", pipelines)
+
+	c := &Capture{}
+	cmd := &cobra.Command{}
+	if err := c.Init(cmd); err != nil {
+		t.Fatal(err)
+	}
+	c.Set()
+	return c
+}
+
+func TestVideoPipelinesEnv(t *testing.T) {
+	const pipeline = "ximagesrc display-name={display} show-pointer=false ! appsink name=appsink"
+
+	t.Run("object entries with gst_pipeline keep working", func(t *testing.T) {
+		c := loadCaptureFromEnv(t, `{"high":{"gst_pipeline":"`+pipeline+`"}}`)
+
+		cfg, ok := c.VideoPipelines["high"]
+		if !ok {
+			t.Fatalf("pipeline entry missing, got %v", c.VideoPipelines)
+		}
+		if cfg.GstPipeline != pipeline {
+			t.Errorf("expected pipeline %q, got %q", pipeline, cfg.GstPipeline)
+		}
+	})
+
+	t.Run("bare pipeline string entries are accepted", func(t *testing.T) {
+		c := loadCaptureFromEnv(t, `{"high":"`+pipeline+`"}`)
+
+		cfg, ok := c.VideoPipelines["high"]
+		if !ok {
+			t.Fatalf("bare pipeline string entry was dropped and neko fell back to the default vp8 pipeline, got %v", c.VideoPipelines)
+		}
+		if cfg.GstPipeline != pipeline {
+			t.Errorf("expected pipeline %q, got %q", pipeline, cfg.GstPipeline)
+		}
+	})
+}

--- a/webpage/docs/configuration/capture.md
+++ b/webpage/docs/configuration/capture.md
@@ -165,6 +165,18 @@ capture:
         gst_pipeline: "<gstreamer_pipeline>"
 ```
 
+As a shorthand, a pipeline entry can also be a plain string instead of an object, which is equivalent to setting only <Opt id="video.pipelines.gst_pipeline" />:
+
+```yaml title="config.yaml"
+capture:
+  video:
+    ...
+    pipelines:
+      <pipeline_id>: "<gstreamer_pipeline>"
+```
+
+This shorthand also works when defining <Opt id="video.pipelines" /> via the `NEKO_CAPTURE_VIDEO_PIPELINES` environment variable as a JSON object, e.g. `NEKO_CAPTURE_VIDEO_PIPELINES='{"<pipeline_id>":"<gstreamer_pipeline>"}'`.
+
 Since now you have to define the whole pipeline, you need to specify the src element to get the video frames and the sink element to send the encoded video frames to neko. In your pipeline, you can use `{display}` as a placeholder for the display name that will be replaced by the actual display name at runtime. You need to set the `name` property of the sink element to `appsink` so that neko can capture the video frames.
 
 Your typical pipeline string would look like this:


### PR DESCRIPTION
Fixes #689

NEKO_CAPTURE_VIDEO_PIPELINES expects every entry to be a full pipeline config object, but the singular NEKO_CAPTURE_VIDEO_PIPELINE option makes people write the whole pipeline as a plain string, so the natural dict shape gets dropped, the error only shows up as a warn in the logs and neko falls back to the default vp8 pipeline, even overriding a directly set NEKO_CAPTURE_VIDEO_CODEC

what happens under the hood: the JSON string hook decodes the env value into a generic map, so the type info is lost before the per entry decoding runs and a plain string value can never reach VideoConfig. the fix adds a small mapstructure hook in the capture config: a string value for an entry now becomes VideoConfig{GstPipeline: ...}, the same shape the single pipeline option produces

object entries are untouched, the yaml config file path gains the same shorthand for free, nothing else in the repo changes

### Steps to reproduce
1. `NEKO_CAPTURE_VIDEO_PIPELINES='{"high":"ximagesrc display-name={display} ! appsink name=appsink"}' go test ./internal/config/ -run TestVideoPipelinesEnv -v`
2. Expected: the entry loads, VideoPipelines has high with the pipeline string in GstPipeline
3. Actual (raw output on untouched master):

```
{"level":"warn","error":"decoding failed due to the following error(s):\n\n'[high]' expected a map or struct, got \"string\"","time":"2026-09-08T10:33:37Z","message":"unable to parse video pipelines"}
{"level":"warn","time":"2026-09-08T10:33:37Z","message":"no video pipelines specified, using default"}
    capture_test.go:52: bare pipeline string entry was dropped and neko fell back to the default vp8 pipeline, got map[main:{  25 0  vp8enc map[...]}]
```

with the fix both subtests pass, go test ./... is green on the server module and go vet is clean